### PR TITLE
Use rev-list --count rather than just rev-list

### DIFF
--- a/astropy_helpers/git_helpers.py
+++ b/astropy_helpers/git_helpers.py
@@ -79,12 +79,12 @@ def get_git_devstr(sha=False, show_warning=True, path=None):
         path = os.path.abspath(os.path.dirname(path))
 
     if sha:
-        cmd = 'rev-parse'  # Faster for getting just the hash of HEAD
+        cmd = ['rev-parse']  # Faster for getting just the hash of HEAD
     else:
-        cmd = 'rev-list'
+        cmd = ['rev-list', '--count']
 
     try:
-        p = subprocess.Popen(['git', cmd, 'HEAD'], cwd=path,
+        p = subprocess.Popen(['git'] + cmd + ['HEAD'], cwd=path,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                              stdin=subprocess.PIPE)
         stdout, stderr = p.communicate()
@@ -107,5 +107,4 @@ def get_git_devstr(sha=False, show_warning=True, path=None):
     if sha:
         return stdout.decode('utf-8')[:40]
     else:
-        nrev = stdout.decode('utf-8').count('\n')
-        return  str(nrev)
+        return stdout.decode('utf-8').strip()


### PR DESCRIPTION
Since we don't actually need the whole `rev-list`, just the number of hashes in the `rev-list`, using `rev-list --count` is a lot faster.

On my machine, this is the bulk of the wall-clock time spent in `setup.py` before handing off to distutils, so I got about a 30% speedup until that point.

(The `submodule status` call is still more expensive than this one, but I don't see any way around it.)
