### PR TITLE
Don't call out to git if we're sure it will fail

### DIFF
--- a/astropy_helpers/git_helpers.py
+++ b/astropy_helpers/git_helpers.py
@@ -78,7 +78,7 @@ def get_git_devstr(sha=False, show_warning=True, path=None):
     if not os.path.isdir(path):
         path = os.path.abspath(os.path.dirname(path))
 
-    if not os.path.isdir(os.path.join(path, '.git')):
+    if not os.path.exists(os.path.join(path, '.git')):
         return ''
 
     if sha:


### PR DESCRIPTION
Calling out to `git` only to have it fail, turns to eat up a fair bit of time when doing `import astropy`.  We can also just detect the presence of a git repository by looking for the `.git` directory, which is much faster.  While I suppose `git` could change its internal representation to do something else in the future, there are _many_ tools that rely on this trick (like bash completion etc.) such that it's unlikely to change without fanfare and hand-wringing.
