### PR TITLE
Added a new ``list_data_files`` function that can be used to search for files recursively

### DIFF
--- a/astropy_helpers/tests/test_utils.py
+++ b/astropy_helpers/tests/test_utils.py
@@ -18,7 +18,7 @@ def test_find_data_files(tmpdir):
 
     filenames = sorted(os.path.relpath(x, data.strpath) for x in filenames)
 
-    assert filenames[0] == 'data.dat'
-    assert filenames[1] == 'sub1/data.dat'
-    assert filenames[2] == 'sub1/sub3/data.dat'
-    assert filenames[3] == 'sub2/data.dat'
+    assert filenames[0] == os.path.join('data.dat')
+    assert filenames[1] == os.path.join('sub1', 'data.dat')
+    assert filenames[2] == os.path.join('sub1', 'sub3', 'data.dat')
+    assert filenames[3] == os.path.join('sub2', 'data.dat')

--- a/astropy_helpers/tests/test_utils.py
+++ b/astropy_helpers/tests/test_utils.py
@@ -1,0 +1,24 @@
+import os
+from ..utils import find_data_files
+
+
+def test_find_data_files(tmpdir):
+
+    data = tmpdir.mkdir('data')
+    sub1 = data.mkdir('sub1')
+    sub2 = data.mkdir('sub2')
+    sub3 = sub1.mkdir('sub3')
+
+    for directory in (data, sub1, sub2, sub3):
+        filename = directory.join('data.dat').strpath
+        with open(filename, 'w') as f:
+            f.write('test')
+
+    filenames = find_data_files(data.strpath, '**/*.dat')
+
+    filenames = sorted(os.path.relpath(x, data.strpath) for x in filenames)
+
+    assert filenames[0] == 'data.dat'
+    assert filenames[1] == 'sub1/data.dat'
+    assert filenames[2] == 'sub1/sub3/data.dat'
+    assert filenames[3] == 'sub2/data.dat'

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -854,7 +854,7 @@ def find_data_files(package, pattern):
     Parameters
     ----------
     package : str
-        The pacakge inside which to look for data files
+        The package inside which to look for data files
     pattern : str
         Pattern (glob-style) to match for the data files (e.g. ``*.dat``).
         This supports the Python 3.5 ``**``recursive syntax. For example,

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -847,7 +847,7 @@ class classproperty(property):
         return fget
 
 
-def list_data_files(package, pattern, subdir='.'):
+def find_data_files(package, pattern, subdir='.'):
     """
     Include files matching ``pattern`` inside ``package``.
 
@@ -865,7 +865,7 @@ def list_data_files(package, pattern, subdir='.'):
          An optional sub-directory inside which to search (e.g. ``data``)
     """
     matches = []
-    for root, dirs, files in os.walk(os.path.join(package, parent)):
+    for root, dirs, files in os.walk(os.path.join(package, subdir)):
         for filename in fnmatch.filter(files, pattern):
             matches.append(os.path.join(os.path.relpath(root, package),
                                         filename))

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -862,7 +862,7 @@ def find_data_files(package, pattern):
         recursively. Only one instance of ``**`` can be included in the
         pattern.
     """
-    
+
     if sys.version_info[:2] >= (3, 5):
         return glob.glob(os.path.join(package, pattern), recursive=True)
     else:
@@ -870,10 +870,10 @@ def find_data_files(package, pattern):
             start, end = pattern.split('**')
             if end.startswith(('/', os.sep)):
                 end = end[1:]
-            matches = []
+            matches = glob.glob(os.path.join(package, start, end))
             for root, dirs, files in os.walk(os.path.join(package, start)):
                 for dirname in dirs:
                     matches += glob.glob(os.path.join(root, dirname, end))
-            return matches            
+            return matches
         else:
             return glob.glob(os.path.join(package, pattern))

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -7,6 +7,7 @@ import imp
 import inspect
 import os
 import sys
+import fnmatch
 import textwrap
 import types
 import warnings
@@ -18,6 +19,7 @@ try:
         import_machinery = None
 except ImportError:
     import_machinery = None
+
 
 
 # Python 3.3's importlib caches filesystem reads for faster imports in the
@@ -843,3 +845,28 @@ class classproperty(property):
         fget.__wrapped__ = orig_fget
 
         return fget
+
+
+def list_data_files(package, pattern, subdir='.'):
+    """
+    Include files matching ``pattern`` inside ``package``.
+
+    Optionally, a sub-directory of ``package``, ``subdir``, can be specified
+    to search only in that particular sub-package. The filenames returned are
+    relative to the ``package`` directory.
+
+    Parameters
+    ----------
+    package : str
+        The pacakge inside which to look for data files
+    pattern : str
+        The pattern to match for the data files (e.g. ``*.dat``)
+    subdir : str, optional
+         An optional sub-directory inside which to search (e.g. ``data``)
+    """
+    matches = []
+    for root, dirs, files in os.walk(os.path.join(package, parent)):
+        for filename in fnmatch.filter(files, pattern):
+            matches.append(os.path.join(os.path.relpath(root, package),
+                                        filename))
+    return matches


### PR DESCRIPTION
In the package-template, we currently search for c files manually:

```
c_files = []
for root, dirs, files in os.walk(PACKAGENAME):
    for filename in files:
        if filename.endswith('.c'):
            c_files.append(
                os.path.join(
                    os.path.relpath(root, PACKAGENAME), filename))
```

we now also need to search for all files in ``packagename/data/`` recursively, so I thought it would be more convenient to write a function to do this.

I can add tests if we think this is a good idea.

cc @embray @mdboom