### PR TITLE
make changelog sphinx extension also apply to whatsnew pages

### DIFF
--- a/astropy_helpers/sphinx/ext/changelog_links.py
+++ b/astropy_helpers/sphinx/ext/changelog_links.py
@@ -75,4 +75,4 @@ def setup(app):
     app.connect('doctree-resolved', process_changelog_links)
     app.connect('builder-inited', setup_patterns_rexes)
     app.add_config_value('github_issues_url', None, True)
-    app.add_config_value('changelog_links_docpattern', ['.*changelog.*'], True)
+    app.add_config_value('changelog_links_docpattern', ['.*changelog.*', 'whatsnew/.*'], True)


### PR DESCRIPTION
This is a pretty simple patch that just makes the `changelog_links` sphinx extension get run on the what's new pages.  We've been using `[#xxxx]` entries on the what's new page, so it seems sensible to allow this.
