### PR TITLE
issue a less intrusive warning for using an old version of git

### DIFF
--- a/astropy_helpers/git_helpers.py
+++ b/astropy_helpers/git_helpers.py
@@ -119,6 +119,12 @@ def get_git_devstr(sha=False, show_warning=True, path=None):
                 warnings.warn('No git repository present at {0!r}! Using '
                               'default dev version.'.format(path))
             return (p.returncode, '', '')
+        if p.returncode == 129:
+            if show_warning:
+                warnings.warn('Your git looks old (does it support {0}?); ' 
+                              'consider upgrading to v1.7.2 or '
+                              'later.'.format(cmd[0]))
+            return (p.returncode, stdout, stderr)
         elif p.returncode != 0:
             if show_warning:
                 warnings.warn('Git failed while determining revision '


### PR DESCRIPTION
When auto-generating a version number, git_helpers will issue a "git rev-list --count" command which can fail if the user has an old version of git that does not support the --count option.  The code detects this and will try a fall-back mechanism.  One side effect of this is that when "git rev-list --count" fails, the whole git rev-list usage message will get printed to standard out as warning.  This will occur every time "python setup.py" gets executed, even with "--help".  

As the fallback mechanism seems to work fine and I haven't seen any other ill effects of an older git version (I have to admit now that I have system where git is at 1.7.0.4.), I might suggest softening the warning message with the patch included here.  Perhaps others are aware of other pit falls to be aware of?
