### PR TITLE
Use six.iteritems for compatibility with python 3

### DIFF
--- a/astropy_helpers/sphinx/ext/viewcode.py
+++ b/astropy_helpers/sphinx/ext/viewcode.py
@@ -18,6 +18,7 @@ from sphinx.locale import _
 from sphinx.pycode import ModuleAnalyzer
 from sphinx.util.nodes import make_refnode
 
+import six
 import sys
 import traceback
 
@@ -129,7 +130,7 @@ def collect_pages(app):
     app.builder.info(' (%d module code pages)' %
                      len(env._viewcode_modules), nonl=1)
 
-    for modname, entry in env._viewcode_modules.iteritems():
+    for modname, entry in six.iteritems(env._viewcode_modules):
         if not entry:
             continue
         code, tags, used, refname = entry
@@ -147,7 +148,7 @@ def collect_pages(app):
         # the collected tags (HACK: this only works if the tag boundaries are
         # properly nested!)
         maxindex = len(lines) - 1
-        for name, docname in used.iteritems():
+        for name, docname in six.iteritems(used):
             type, start, end = tags[name]
             backlink = urito(pagename, docname) + '#' + refname + '.' + name
             lines[start] = (


### PR DESCRIPTION
Use `six.iteritems` function to support python 2 and 3

Fixes issue #12
