### PR TITLE
New Sphinx with extra values to unpack

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ astropy-helpers Changelog
 0.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed automodsumm to work with new versions of Sphinx (>= 1.2.2). [#79]
 
 
 0.4.1 (2014-08-08)

--- a/astropy_helpers/sphinx/ext/automodsumm.py
+++ b/astropy_helpers/sphinx/ext/automodsumm.py
@@ -417,6 +417,9 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
 
         try:
             name, obj, parent = import_by_name(name)
+        except ValueError:
+            # This exception is to accomodate v1.2.2 and v1.2.3 of Sphinx
+            name, obj, parent, module_name = import_by_name(name)
         except ImportError as e:
             warn('[automodsumm] failed to import %r: %s' % (name, e))
             continue


### PR DESCRIPTION
The current version of sphinx installed by conda (v1.2.2) doesn't show the error the newer version produces:  `ValueError:  too many values to unpack` because the elements are not unpacked to the right amount of variables.   This PR (originally in astropy/astropy#2914) add an extra variable to unpack all the elements properly.

In case you are interested, this was introduced in Sphinx by [this commit](https://bitbucket.org/birkenfeld/sphinx/commits/f4743ba9521feb16bedc98f29275868054f01d67)
