### PR TITLE
Fix Jinja version installed by Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 
 install:
     - $PIP_WHEEL_COMMAND "pytest<2.6"
+    - $PIP_WHEEL_COMMAND "Jinja2<2.7"
     - $PIP_WHEEL_COMMAND "Sphinx"
     - $PIP_WHEEL_COMMAND "pytest-cov"
     - $PIP_WHEEL_COMMAND "coveralls"


### PR DESCRIPTION
Apparently Jinja2 v2.7 dropped support for Python 3.2, but when we install Sphinx it's pulling in the latest Jinja2 release which breaks the build for Python 3.2.  So ensure an older version is used (Sphinx is requesting >=2.3 so this should be okay).
