### PR TITLE
Skip argument of doctest-skip in the sphinx output

### DIFF
--- a/astropy_helpers/sphinx/ext/doctest.py
+++ b/astropy_helpers/sphinx/ext/doctest.py
@@ -9,6 +9,7 @@ which actually does something.  For astropy, all of the testing is
 centrally managed from py.test and Sphinx is not used for running
 tests.
 """
+import re
 from docutils.nodes import literal_block
 from sphinx.util.compat import Directive
 
@@ -17,6 +18,10 @@ class DoctestSkipDirective(Directive):
     has_content = True
 
     def run(self):
+        # Check if there is any valid argument, and skip it. Currently only
+        # 'win32' is supported in astropy.tests.pytest_plugins.
+        if re.match('win32', self.content[0]):
+            self.content = self.content[2:]
         code = '\n'.join(self.content)
         return [literal_block(code, code)]
 


### PR DESCRIPTION
The doctest-skip argument was introduced in https://github.com/astropy/astropy/pull/2459 for the test itself, however the argument isn't recognized by sphinx when generating the docs. 

see the 'win32' text left behind in these examples:
http://docs.astropy.org/en/latest/table/operations.html#identical-keys

I can't test on windows, but I think this shouldn't brake anything there.
