### PR TITLE
Don’t use git if there is no .git directory

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -153,6 +153,12 @@ class _Bootstrapper(object):
         self.auto_upgrade = (auto_upgrade
                              if auto_upgrade is not None else AUTO_UPGRADE)
 
+        # If this is a release then the .git directory will not exist so we
+        # should not use git.
+        git_dir_exists = os.path.exists(os.path.join(os.path.dirname(__file__), '.git'))
+        if use_git is None and not git_dir_exists:
+            use_git = False
+
         self.use_git = use_git if use_git is not None else USE_GIT
         # Declared as False by default--later we check if astropy-helpers can be
         # upgraded from PyPI, but only if not using a source distribution (as in


### PR DESCRIPTION
@embray - this seems to fix https://github.com/astropy/astropy/issues/2926

By the way, I noticed that astropy core is still using the old `ah_bootstrap.py` - is that intentional, or should we update it?
