### PR TITLE
Coverage is incomplete due to some tests running in sub-processes

### DIFF
--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -187,4 +187,7 @@ def test_build_sphinx(tmpdir, mode):
     elif mode == 'direct':  # to check coverage
         docs_dir.chdir()
         from sphinx import main
-        assert main(['-b html', '-d _build/doctrees', '.', '_build/html']) == 0
+        try:
+            main(['-b html', '-d _build/doctrees', '.', '_build/html'])
+        except SystemExit as exc:
+            assert exc.code == 0


### PR DESCRIPTION
Our coverage is actually better than what is reported by the coverage plug-in - the issue is because e.g. sphinx is being run in a subprocess, the coverage isn't being reported for a lot of the sphinx code. It would be nice to find a way to run sphinx without instantiating a subprocess in order to better see which code we cover.
