### PR TITLE
Remove unused imports

### DIFF
--- a/astropy_helpers/sphinx/ext/tests/test_automodapi.py
+++ b/astropy_helpers/sphinx/ext/tests/test_automodapi.py
@@ -6,7 +6,6 @@ import sys
 import pytest
 
 from . import *
-from ....tests import *
 from ....utils import iteritems
 
 pytest.importorskip('sphinx')  # skips these tests if sphinx not present

--- a/astropy_helpers/sphinx/ext/tests/test_automodsumm.py
+++ b/astropy_helpers/sphinx/ext/tests/test_automodsumm.py
@@ -5,7 +5,6 @@ import sys
 import pytest
 
 from . import *
-from ....tests import *
 from ....utils import iteritems
 
 pytest.importorskip('sphinx')  # skips these tests if sphinx not present


### PR DESCRIPTION
Noticed this when testing the release version (since the release version doesn't include `astropy_helpers.tests` - turns out these imports are left over from the astropy core days I guess.
