### PR TITLE
Emit a warning if a public object has no docstring

### DIFF
--- a/astropy_helpers/sphinx/ext/astropyautosummary.py
+++ b/astropy_helpers/sphinx/ext/astropyautosummary.py
@@ -75,7 +75,7 @@ class AstropyAutosummary(Autosummary):
             # -- Grab the summary
 
             raw_doc = documenter.get_doc()
-            if len(raw_doc) == 0:
+            if env.config.require_docstring_on_public_objects and len(raw_doc) == 0:
                 self.warn('[astropyautosummary] public object {0} does not have a docstring'.format(display_name))
             doc = list(documenter.process_doc(raw_doc))
 
@@ -99,3 +99,4 @@ def setup(app):
     app.setup_extension('sphinx.ext.autosummary')
     # this replaces the default autosummary with the astropy one
     app.add_directive('autosummary', AstropyAutosummary)
+    app.add_config_value('require_docstring_on_public_objects', False, True)

--- a/astropy_helpers/sphinx/ext/astropyautosummary.py
+++ b/astropy_helpers/sphinx/ext/astropyautosummary.py
@@ -74,7 +74,10 @@ class AstropyAutosummary(Autosummary):
 
             # -- Grab the summary
 
-            doc = list(documenter.process_doc(documenter.get_doc()))
+            raw_doc = documenter.get_doc()
+            if len(raw_doc) == 0:
+                self.warn('[astropyautosummary] public object {0} does not have a docstring'.format(display_name))
+            doc = list(documenter.process_doc(raw_doc))
 
             while doc and not doc[0].strip():
                 doc.pop(0)

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -129,12 +129,15 @@ def test_build_sphinx(tmpdir, mode):
 
     test_pkg.join('mypackage').join('__init__.py').write(dedent("""\
         def test_function():
+            "Test function"
             pass
 
         class A():
+            "Test class A"
             pass
 
         class B(A):
+            "Test class B"
             pass
     """))
 

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -159,6 +159,7 @@ def test_build_sphinx(tmpdir, mode):
             warnings.simplefilter("ignore")
             from astropy_helpers.sphinx.conf import *
         exclude_patterns.append('_templates')
+        require_docstring_on_public_objects = True
     """))
 
     docs_dir.join('index.rst').write(dedent("""\


### PR DESCRIPTION
This was originally https://github.com/astropy/astropy/pull/2136 - I don't think we should merge as-is but instead make it an opt-in option that can be set in ``conftest.py``. Then even if we never enable it by default in astropy core we can then enable it from time to time locally for testing.