### PR TITLE
Avoid using Python 2.7.9 on Travis until certificate issue is resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,16 @@ before_install:
     - sudo apt-get install graphviz
 
 install:
-    - conda install --yes pip "pytest<2.6" sphinx cython numpy
+
+    # Certificate checking is not working with Python 2.7.9 (due to PEP 476)
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then export TRAVIS_PYTHON_VERSION=2.7.8; fi
+
+    - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
+    - source activate test
+
+    - export CONDA_INSTALL="conda install -c astropy-ci-extras --yes python=$TRAVIS_PYTHON_VERSION
+
+    - $CONDA_INSTALL pip "pytest<2.6" sphinx cython numpy
     - pip install coveralls pytest-cov
 
 before_script:


### PR DESCRIPTION
Also, fun fact, we were actually only testing with Python 2.7.9 under all configurations. This PR fixes that.

cc @embray
