### PR TITLE
Some Python 3 fixes for the import_file utility

### DIFF
--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -5,6 +5,11 @@ import imp
 import os
 import sys
 
+try:
+    from importlib import machinery as import_machinery
+except ImportError:
+    import_machinery = None
+
 
 # Python 3.3's importlib caches filesystem reads for faster imports in the
 # general case. But sometimes it's necessary to manually invalidate those
@@ -199,11 +204,20 @@ def import_file(filename, name=None):
     # generates an underscore-separated name which is more likely to
     # be unique, and it doesn't really matter because the name isn't
     # used directly here anyway.
-    with open(filename, 'U') as fd:
-        if name is None:
-            basename = os.path.splitext(filename)[0]
-            name = '_'.join(os.path.relpath(basename).split(os.sep)[1:])
-        return imp.load_module(name, fd, filename, ('.py', 'U', 1))
+    mode = 'U' if sys.version_info[0] < 3 else 'r'
+
+    if name is None:
+        basename = os.path.splitext(filename)[0]
+        name = '_'.join(os.path.relpath(basename).split(os.sep)[1:])
+
+    if import_machinery:
+        loader = import_machinery.SourceFileLoader(name, filename)
+        mod = loader.load_module()
+    else:
+        with open(filename, mode) as fd:
+            mod = imp.load_module(name, fd, filename, ('.py', mode, 1))
+
+    return mod
 
 
 def resolve_name(name):


### PR DESCRIPTION
Don't use the deprecated 'U' file mode, and use importlib instead of imp to do the importing.
