### PR TITLE
Add a Travis config to test with the latest developer version of setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ python:
     - 3.3
     - 3.4
 
+env:
+    global:
+        - SETUPTOOLS_VERSION=stable
+
+matrix:
+    include:
+        - python: 2.7
+          env: SETUPTOOLS_VERSION=dev
+
 before_install:
 
     # Use utf8 encoding. Should be default, but this is insurance against
@@ -27,8 +36,9 @@ before_install:
     - sudo apt-get install graphviz
 
 install:
-    - conda install --yes pip "pytest<2.6" sphinx cython numpy
+    - conda install --yes pip "pytest<2.6" sphinx cython numpy mercurial mock
     - pip install coveralls pytest-cov
+    - if [[ $SETUPTOOLS_VERSION == dev ]]; then hg clone https://bitbucket.org/pypa/setuptools; cd setuptools; python setup.py install; cd ..; fi
 
 before_script:
     # Some of the tests use git commands that require a user to be configured

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ before_install:
 install:
     - conda install --yes pip "pytest<2.6" sphinx cython numpy mercurial mock
     - pip install coveralls pytest-cov
+    # We cannot install the developer version of setuptools using pip because
+    # pip tries to remove the previous version of setuptools before the
+    # installation is complete, which causes issues. Instead, we just install
+    # setuptools manually.
     - if [[ $SETUPTOOLS_VERSION == dev ]]; then hg clone https://bitbucket.org/pypa/setuptools; cd setuptools; python setup.py install; cd ..; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_script:
     - git config --global user.email "author@example.com"
 
 script:
-    - py.test --cov astropy_helpers
+    - py.test --cov astropy_helpers astropy_helpers
 
 after_success:
     - coveralls


### PR DESCRIPTION
For once we figure out #124 and get the tests working again - I think it would be good to have a config on travis that tests the latest developer version of setuptools. We can even have a cron job that restarts the Travis job nightly since changes in setuptools likely happen faster than in astropy-helpers.