### PR TITLE
Errors with latest setuptools

### DIFF
--- a/astropy_helpers/tests/__init__.py
+++ b/astropy_helpers/tests/__init__.py
@@ -2,6 +2,8 @@ import os
 import subprocess as sp
 import sys
 
+from setuptools import sandbox
+
 import pytest
 
 PACKAGE_DIR = os.path.dirname(__file__)
@@ -64,6 +66,23 @@ def reset_distutils_log():
 
     from distutils import log
     log.set_threshold(log.WARN)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def fix_hide_setuptools():
+    """
+    Workaround for https://github.com/astropy/astropy-helpers/issues/124
+
+    In setuptools 10.0 run_setup was changed in such a way that it sweeps
+    away the existing setuptools import before running the setup script.  In
+    principle this is nice, but in the practice of testing astropy_helpers
+    this is problematic since we're trying to test code that has already been
+    imported during the testing process, and which relies on the setuptools
+    module that was already in use.
+    """
+
+    if hasattr(sandbox, 'hide_setuptools'):
+        sandbox.hide_setuptools = lambda: None
 
 
 TEST_PACKAGE_SETUP_PY = """\


### PR DESCRIPTION
As discussed in https://github.com/astropy/astropy-helpers/pull/123, conda now installs ``setuptools=11.3.1`` by default which is causing failures in the tests

```
[1m============================= test session starts ==============================[0m
platform linux2 -- Python 2.7.9 -- py-1.4.26 -- pytest-2.6.4
plugins: cov
[1m
collecting 0 items[0m[1m
collecting 0 items[0m[1m
collecting 7 items[0m[1m
collecting 9 items[0m[1m
collecting 36 items[0m[1m
collecting 37 items[0m[1m
collecting 45 items[0m[1m
collecting 47 items[0m[1m
collecting 53 items[0m[1m
collected 53 items 
[0m
astropy_helpers/sphinx/ext/tests/test_automodapi.py .......
astropy_helpers/sphinx/ext/tests/test_automodsumm.py ..
astropy_helpers/sphinx/ext/tests/test_docscrape.py ...........................
astropy_helpers/sphinx/ext/tests/test_utils.py .
astropy_helpers/tests/test_ah_bootstrap.py .....FFF
astropy_helpers/tests/test_git_helpers.py ..
astropy_helpers/tests/test_setup_helpers.py .FFF..

=================================== FAILURES ===================================
_________________________ test_bootstrap_from_archive __________________________

tmpdir = local('/tmp/pytest-0/test_bootstrap_from_archive0')
testpackage = local('/tmp/pytest-0/test_bootstrap_from_archive0/testpkg')
capsys = <_pytest.capture.CaptureFixture instance at 0x7f9787148cf8>

[1m    def test_bootstrap_from_archive(tmpdir, testpackage, capsys):[0m
[1m        """[0m
[1m        Tests importing _astropy_helpers_test_ from a .tar.gz source archive[0m
[1m        shipped alongside the package that uses it.[0m
[1m        """[0m
[1m    [0m
[1m        orig_repo = tmpdir.mkdir('orig')[0m
[1m    [0m
[1m        # Ensure ah_bootstrap is imported from the local directory[0m
[1m        import ah_bootstrap[0m
[1m    [0m
[1m        # Make a source distribution of the test package[0m
[1m        with silence():[0m
[1m            run_setup(str(testpackage.join('setup.py')),[0m
[1m                      ['sdist', '--dist-dir=dist', '--formats=gztar'])[0m
[1m    [0m
[1m        dist_dir = testpackage.join('dist')[0m
[1m        for dist_file in dist_dir.visit('*.tar.gz'):[0m
[1m            dist_file.copy(orig_repo)[0m
[1m    [0m
[1m        with orig_repo.as_cwd():[0m
[1m            # Write a test setup.py that uses ah_bootstrap; it also ensures that[0m
[1m            # any previous reference to astropy_helpers is first wiped from[0m
[1m            # sys.modules[0m
[1m            args = 'path={0!r}'.format(os.path.basename(str(dist_file)))[0m
[1m            orig_repo.join('setup.py').write(TEST_SETUP_PY.format(args=args))[0m
[1m    [0m
[1m>           run_setup('setup.py', [])[0m

/home/travis/build/astropy/astropy-helpers/astropy_helpers/tests/test_ah_bootstrap.py:248: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:204: in run_setup
[1m    raise[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:128: in save_modules
[1m    compat.reraise(new_cls, new_exc, tb)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:106: in save_modules
[1m    yield saved[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:201: in run_setup
[1m    DirectorySandbox(setup_dir).run(runner)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:231: in run
[1m    return func()[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:200: in runner
[1m    _execfile(setup_script, ns)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:46: in _execfile
[1m    exec(code, globals, locals)[0m
setup.py:17: in <module>
[1m    version=VERSION,[0m
/home/travis/build/astropy/astropy-helpers/ah_bootstrap.py:880: in use_astropy_helpers
[1m    bootstrapper.run()[0m
/home/travis/build/astropy/astropy-helpers/ah_bootstrap.py:272: in run
[1m    pkg_resources.working_set.add(dist)[0m
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pkg_resources.WorkingSet object at 0x7f97896b0950>, dist = False
entry = None, insert = True, replace = False

[1m    def add(self, dist, entry=None, insert=True, replace=False):[0m
[1m        """Add `dist` to working set, associated with `entry`[0m
[1m    [0m
[1m            If `entry` is unspecified, it defaults to the ``.location`` of `dist`.[0m
[1m            On exit from this routine, `entry` is added to the end of the working[0m
[1m            set's ``.entries`` (if it wasn't already present).[0m
[1m    [0m
[1m            `dist` is only added to the working set if it's for a project that[0m
[1m            doesn't already have a distribution in the set, unless `replace=True`.[0m
[1m            If it's added, any callbacks registered with the ``subscribe()`` method[0m
[1m            will be called.[0m
[1m            """[0m
[1m        if insert:[0m
[1m>           dist.insert_on(self.entries, entry)[0m
[1m[31mE           AttributeError: 'bool' object has no attribute 'insert_on'[0m

/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/pkg_resources/__init__.py:728: AttributeError
----------------------------- Captured stderr call -----------------------------
Failed to import _astropy_helpers_test_ from the specified archive 'astropy-helpers-test-0.1.tar.gz': Error retrieving astropy-helpers-test from astropy-helpers-test-0.1.tar.gz:
TypeError('dist must be a Distribution instance',)
Downloading 'astropy-helpers-test' disabled.
___________________________ test_download_if_needed ____________________________

tmpdir = local('/tmp/pytest-0/test_download_if_needed0')
testpackage = local('/tmp/pytest-0/test_download_if_needed0/testpkg')
capsys = <_pytest.capture.CaptureFixture instance at 0x7f9786cca1b8>

[1m    def test_download_if_needed(tmpdir, testpackage, capsys):[0m
[1m        """[0m
[1m        Tests the case where astropy_helpers was not actually included in a[0m
[1m        package, or is otherwise missing, and we need to "download" it.[0m
[1m    [0m
[1m        This does not test actually downloading from the internet--this is normally[0m
[1m        done through setuptools' easy_install command which can also install from a[0m
[1m        source archive.  From the point of view of ah_boostrap the two actions are[0m
[1m        equivalent, so we can just as easily simulate this by providing a setup.cfg[0m
[1m        giving the path to a source archive to "download" (as though it were a[0m
[1m        URL).[0m
[1m        """[0m
[1m    [0m
[1m        source = tmpdir.mkdir('source')[0m
[1m    [0m
[1m        # Ensure ah_bootstrap is imported from the local directory[0m
[1m        import ah_bootstrap[0m
[1m    [0m
[1m        # Make a source distribution of the test package[0m
[1m        with silence():[0m
[1m            run_setup(str(testpackage.join('setup.py')),[0m
[1m                      ['sdist', '--dist-dir=dist', '--formats=gztar'])[0m
[1m    [0m
[1m        dist_dir = testpackage.join('dist')[0m
[1m    [0m
[1m        with source.as_cwd():[0m
[1m            source.join('setup.py').write(TEST_SETUP_PY.format([0m
[1m                args='download_if_needed=True'))[0m
[1m            source.join('setup.cfg').write(textwrap.dedent("""\[0m
[1m                [easy_install][0m
[1m                find_links = {find_links}[0m
[1m            """.format(find_links=str(dist_dir))))[0m
[1m    [0m
[1m>           run_setup('setup.py', [])[0m

/home/travis/build/astropy/astropy-helpers/astropy_helpers/tests/test_ah_bootstrap.py:300: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:204: in run_setup
[1m    raise[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:128: in save_modules
[1m    compat.reraise(new_cls, new_exc, tb)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:106: in save_modules
[1m    yield saved[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:201: in run_setup
[1m    DirectorySandbox(setup_dir).run(runner)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:231: in run
[1m    return func()[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:200: in runner
[1m    _execfile(setup_script, ns)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:46: in _execfile
[1m    exec(code, globals, locals)[0m
setup.py:17: in <module>
[1m    version=VERSION,[0m
/home/travis/build/astropy/astropy-helpers/ah_bootstrap.py:880: in use_astropy_helpers
[1m    bootstrapper.run()[0m
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ah_bootstrap._Bootstrapper object at 0x7f9786b0f550>

[1m    def run(self):[0m
[1m        strategies = ['local_directory', 'local_file', 'index'][0m
[1m        dist = None[0m
[1m    [0m
[1m        # Check to see if the path is a submodule[0m
[1m        self.is_submodule = self._check_submodule()[0m
[1m    [0m
[1m        for strategy in strategies:[0m
[1m            method = getattr(self, 'get_{0}_dist'.format(strategy))[0m
[1m            dist = method()[0m
[1m            if dist is not None:[0m
[1m                break[0m
[1m        else:[0m
[1m            raise _AHBootstrapSystemExit([0m
[1m                "No source found for the {0!r} package; {0} must be "[0m
[1m                "available and importable as a prerequisite to building "[0m
[1m>               "or installing this package.".format(PACKAGE_NAME))[0m
[1m[31mE           _AHBootstrapSystemExit: No source found for the '_astropy_helpers_test_' package; _astropy_helpers_test_ must be available and importable as a prerequisite to building or installing this package.[0m
[1m[31mE           [0m
[1m[31mE           If the problem persists consider installing astropy_helpers manually using pip[0m
[1m[31mE           (`pip install astropy_helpers`) or by manually downloading the source archive,[0m
[1m[31mE           extracting it, and installing by running `python setup.py install` from the[0m
[1m[31mE           root of the extracted source code.[0m
[1m[31mE           [0m
[1m[31mE           [0m
[1m[31mE           If the problem persists consider installing astropy_helpers manually using pip[0m
[1m[31mE           (`pip install astropy_helpers`) or by manually downloading the source archive,[0m
[1m[31mE           extracting it, and installing by running `python setup.py install` from the[0m
[1m[31mE           root of the extracted source code.[0m

/home/travis/build/astropy/astropy-helpers/ah_bootstrap.py:264: _AHBootstrapSystemExit
----------------------------- Captured stderr call -----------------------------
git submodule command failed unexpectedly:
fatal: Not a git repository (or any of the parent directories): .git
Downloading 'astropy-helpers-test'; run setup.py with the --offline option to force offline installation.
Failed to download and/or install 'astropy-helpers-test' from 'https://pypi.python.org/simple':
Error retrieving astropy-helpers-test from PyPI:
TypeError('dist must be a Distribution instance',)
_________________________________ test_upgrade _________________________________

tmpdir = local('/tmp/pytest-0/test_upgrade0')
capsys = <_pytest.capture.CaptureFixture instance at 0x7f9786071320>

[1m    def test_upgrade(tmpdir, capsys):[0m
[1m        # Run the testpackage fixture manually, since we use it multiple times in[0m
[1m        # this test to make different versions of _astropy_helpers_test_[0m
[1m        orig_dir = testpackage(tmpdir.mkdir('orig'))[0m
[1m    [0m
[1m        # Make a test package that uses _astropy_helpers_test_[0m
[1m        source = tmpdir.mkdir('source')[0m
[1m        dist_dir = source.mkdir('dists')[0m
[1m        orig_dir.copy(source.join('_astropy_helpers_test_'))[0m
[1m    [0m
[1m        with source.as_cwd():[0m
[1m            setup_py = TEST_SETUP_PY.format(args='auto_upgrade=True')[0m
[1m            source.join('setup.py').write(setup_py)[0m
[1m    [0m
[1m            # This will be used to later to fake downloading the upgrade package[0m
[1m            source.join('setup.cfg').write(textwrap.dedent("""\[0m
[1m                [easy_install][0m
[1m                find_links = {find_links}[0m
[1m            """.format(find_links=str(dist_dir))))[0m
[1m    [0m
[1m        # Make additional "upgrade" versions of the _astropy_helpers_test_[0m
[1m        # package--one of them is version 0.2 and the other is version 0.1.1.  The[0m
[1m        # auto-upgrade should ignore version 0.2 but use version 0.1.1.[0m
[1m        upgrade_dir_1 = testpackage(tmpdir.mkdir('upgrade_1'), version='0.2')[0m
[1m        upgrade_dir_2 = testpackage(tmpdir.mkdir('upgrade_2'), version='0.1.1')[0m
[1m    [0m
[1m        dists = [][0m
[1m        # For each upgrade package go ahead and build a source distribution of it[0m
[1m        # and copy that source distribution to a dist directory we'll use later to[0m
[1m        # simulate a 'download'[0m
[1m        for upgrade_dir in [upgrade_dir_1, upgrade_dir_2]:[0m
[1m            with silence():[0m
[1m                run_setup(str(upgrade_dir.join('setup.py')),[0m
[1m                          ['sdist', '--dist-dir=dist', '--formats=gztar'])[0m
[1m            dists.append(str(upgrade_dir.join('dist')))[0m
[1m            for dist_file in upgrade_dir.visit('*.tar.gz'):[0m
[1m                dist_file.copy(source.join('dists'))[0m
[1m    [0m
[1m        # Monkey with the PackageIndex in ah_bootstrap so that it is initialized[0m
[1m        # with the test upgrade packages, and so that it does not actually go out[0m
[1m        # to the internet to look for anything[0m
[1m        import ah_bootstrap[0m
[1m    [0m
[1m        class FakePackageIndex(PackageIndex):[0m
[1m            def __init__(self, *args, **kwargs):[0m
[1m                PackageIndex.__init__(self, *args, **kwargs)[0m
[1m                self.to_scan = dists[0m
[1m    [0m
[1m            def find_packages(self, requirement):[0m
[1m                # no-op[0m
[1m                pass[0m
[1m    [0m
[1m        ah_bootstrap.PackageIndex = FakePackageIndex[0m
[1m    [0m
[1m        try:[0m
[1m            with source.as_cwd():[0m
[1m                # Now run the source setup.py; this test is similar to[0m
[1m                # test_download_if_needed, but we explicitly check that the correct[0m
[1m                # *version* of _astropy_helpers_test_ was used[0m
[1m>               run_setup('setup.py', [])[0m

/home/travis/build/astropy/astropy-helpers/astropy_helpers/tests/test_ah_bootstrap.py:381: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:204: in run_setup
[1m    raise[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:128: in save_modules
[1m    compat.reraise(new_cls, new_exc, tb)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:106: in save_modules
[1m    yield saved[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:201: in run_setup
[1m    DirectorySandbox(setup_dir).run(runner)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:231: in run
[1m    return func()[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:200: in runner
[1m    _execfile(setup_script, ns)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:46: in _execfile
[1m    exec(code, globals, locals)[0m
setup.py:17: in <module>
[1m    version=VERSION,[0m
/home/travis/build/astropy/astropy-helpers/ah_bootstrap.py:880: in use_astropy_helpers
[1m    bootstrapper.run()[0m
/home/travis/build/astropy/astropy-helpers/ah_bootstrap.py:257: in run
[1m    dist = method()[0m
/home/travis/build/astropy/astropy-helpers/ah_bootstrap.py:297: in get_local_directory_dist
[1m    upgrade = self._do_upgrade(dist)[0m
/home/travis/build/astropy/astropy-helpers/ah_bootstrap.py:462: in _do_upgrade
[1m    return self._do_download(version=upgrade.version)[0m
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ah_bootstrap._Bootstrapper object at 0x7f9786de6fd0>, version = '0.1.1'
find_links = None

[1m    def _do_download(self, version='', find_links=None):[0m
[1m        if find_links:[0m
[1m            allow_hosts = ''[0m
[1m            index_url = None[0m
[1m        else:[0m
[1m            allow_hosts = None[0m
[1m            index_url = self.index_url[0m
[1m    [0m
[1m        # Annoyingly, setuptools will not handle other arguments to[0m
[1m        # Distribution (such as options) before handling setup_requires, so it[0m
[1m        # is not straightforward to programmatically augment the arguments which[0m
[1m        # are passed to easy_install[0m
[1m        class _Distribution(Distribution):[0m
[1m            def get_option_dict(self, command_name):[0m
[1m                opts = Distribution.get_option_dict(self, command_name)[0m
[1m                if command_name == 'easy_install':[0m
[1m                    if find_links is not None:[0m
[1m                        opts['find_links'] = ('setup script', find_links)[0m
[1m                    if index_url is not None:[0m
[1m                        opts['index_url'] = ('setup script', index_url)[0m
[1m                    if allow_hosts is not None:[0m
[1m                        opts['allow_hosts'] = ('setup script', allow_hosts)[0m
[1m                return opts[0m
[1m    [0m
[1m        if version:[0m
[1m            req = '{0}=={1}'.format(DIST_NAME, version)[0m
[1m        else:[0m
[1m            req = DIST_NAME[0m
[1m    [0m
[1m        attrs = {'setup_requires': [req]}[0m
[1m    [0m
[1m        try:[0m
[1m            if DEBUG:[0m
[1m                _Distribution(attrs=attrs)[0m
[1m            else:[0m
[1m                with _silence():[0m
[1m                    _Distribution(attrs=attrs)[0m
[1m    [0m
[1m            # If the setup_requires succeeded it will have added the new dist to[0m
[1m            # the main working_set[0m
[1m            return pkg_resources.working_set.by_key.get(DIST_NAME)[0m
[1m        except Exception as e:[0m
[1m            if DEBUG:[0m
[1m                raise[0m
[1m    [0m
[1m            msg = 'Error retrieving {0} from {1}:\n{2}'[0m
[1m            if find_links:[0m
[1m                source = find_links[0][0m
[1m            elif index_url != INDEX_URL:[0m
[1m                source = index_url[0m
[1m            else:[0m
[1m                source = 'PyPI'[0m
[1m    [0m
[1m>           raise Exception(msg.format(DIST_NAME, source, repr(e)))[0m
[1m[31mE           Exception: Error retrieving astropy-helpers-test from PyPI:[0m
[1m[31mE           TypeError('dist must be a Distribution instance',)[0m

/home/travis/build/astropy/astropy-helpers/ah_bootstrap.py:445: Exception
----------------------------- Captured stderr call -----------------------------
git submodule command failed unexpectedly:
fatal: Not a git repository (or any of the parent directories): .git
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/pkg_resources/__init__.py:188: RuntimeWarning: You have iterated over the result of pkg_resources.parse_version. This is a legacy behavior which is inconsistent with the new version class introduced in setuptools 8.0. That class should be used directly instead of attempting to iterate over the result.
  stacklevel=1,
___________________________ test_no_cython_buildext ____________________________

tmpdir = local('/tmp/pytest-0/test_no_cython_buildext0')

[1m    def test_no_cython_buildext(tmpdir):[0m
[1m        """[0m
[1m        Regression test for https://github.com/astropy/astropy-helpers/pull/35[0m
[1m    [0m
[1m        This tests the custom build_ext command installed by astropy_helpers when[0m
[1m        used with a project that has no Cython extensions (but does have one or[0m
[1m        more normal C extensions).[0m
[1m        """[0m
[1m    [0m
[1m        # In order for this test to test the correct code path we need to fool[0m
[1m        # setup_helpers into thinking we don't have Cython installed[0m
[1m        setup_helpers._module_state['have_cython'] = False[0m
[1m    [0m
[1m        test_pkg = tmpdir.mkdir('test_pkg')[0m
[1m        test_pkg.mkdir('_eva_').ensure('__init__.py')[0m
[1m    [0m
[1m        # TODO: It might be later worth making this particular test package into a[0m
[1m        # reusable fixture for other build_ext tests[0m
[1m    [0m
[1m        # A minimal C extension for testing[0m
[1m        test_pkg.join('_eva_').join('unit01.c').write(dedent("""\[0m
[1m            #include <Python.h>[0m
[1m            #ifndef PY3K[0m
[1m            #if PY_MAJOR_VERSION >= 3[0m
[1m            #define PY3K 1[0m
[1m            #else[0m
[1m            #define PY3K 0[0m
[1m            #endif[0m
[1m            #endif[0m
[1m    [0m
[1m            #if PY3K[0m
[1m            static struct PyModuleDef moduledef = {[0m
[1m                PyModuleDef_HEAD_INIT,[0m
[1m                "unit01",[0m
[1m                NULL,[0m
[1m                -1,[0m
[1m                NULL[0m
[1m            };[0m
[1m            PyMODINIT_FUNC[0m
[1m            PyInit_unit01(void) {[0m
[1m                return PyModule_Create(&moduledef);[0m
[1m            }[0m
[1m            #else[0m
[1m            PyMODINIT_FUNC[0m
[1m            initunit01(void) {[0m
[1m                Py_InitModule3("unit01", NULL, NULL);[0m
[1m            }[0m
[1m            #endif[0m
[1m        """))[0m
[1m    [0m
[1m        test_pkg.join('setup.py').write(dedent("""\[0m
[1m            from os.path import join[0m
[1m            from setuptools import setup, Extension[0m
[1m            from astropy_helpers.setup_helpers import register_commands[0m
[1m    [0m
[1m            NAME = '_eva_'[0m
[1m            VERSION = 0.1[0m
[1m            RELEASE = True[0m
[1m    [0m
[1m            cmdclassd = register_commands(NAME, VERSION, RELEASE)[0m
[1m    [0m
[1m            setup([0m
[1m                name=NAME,[0m
[1m                version=VERSION,[0m
[1m                cmdclass=cmdclassd,[0m
[1m                ext_modules=[Extension('_eva_.unit01',[0m
[1m                                       [join('_eva_', 'unit01.c')])][0m
[1m            )[0m
[1m        """))[0m
[1m    [0m
[1m        with test_pkg.as_cwd():[0m
[1m>           run_setup('setup.py', ['build_ext', '--inplace'])[0m

/home/travis/build/astropy/astropy-helpers/astropy_helpers/tests/test_setup_helpers.py:108: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:204: in run_setup
[1m    raise[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:128: in save_modules
[1m    compat.reraise(new_cls, new_exc, tb)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:106: in save_modules
[1m    yield saved[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:201: in run_setup
[1m    DirectorySandbox(setup_dir).run(runner)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:231: in run
[1m    return func()[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:200: in runner
[1m    _execfile(setup_script, ns)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:46: in _execfile
[1m    exec(code, globals, locals)[0m
setup.py:16: in <module>
[1m    name=NAME,[0m
/home/travis/miniconda/lib/python2.7/distutils/core.py:137: in setup
[1m    ok = dist.parse_command_line()[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/dist.py:297: in parse_command_line
[1m    result = _Distribution.parse_command_line(self)[0m
/home/travis/miniconda/lib/python2.7/distutils/dist.py:467: in parse_command_line
[1m    args = self._parse_command_opts(parser, args)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/dist.py:599: in _parse_command_opts
[1m    nargs = _Distribution._parse_command_opts(self, parser, args)[0m
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <setuptools.dist.Distribution instance at 0x7f9786fea1b8>
parser = <distutils.fancy_getopt.FancyGetopt instance at 0x7f9785ebe680>
args = ['build_ext', '--inplace']

[1m    def _parse_command_opts(self, parser, args):[0m
[1m        """Parse the command-line options for a single command.[0m
[1m            'parser' must be a FancyGetopt instance; 'args' must be the list[0m
[1m            of arguments, starting with the current command (whose options[0m
[1m            we are about to parse).  Returns a new version of 'args' with[0m
[1m            the next command at the front of the list; will be the empty[0m
[1m            list if there are no more commands on the command line.  Returns[0m
[1m            None if the user asked for help on this command.[0m
[1m            """[0m
[1m        # late import because of mutual dependence between these modules[0m
[1m        from distutils.cmd import Command[0m
[1m    [0m
[1m        # Pull the current command from the head of the command line[0m
[1m        command = args[0][0m
[1m        if not command_re.match(command):[0m
[1m            raise SystemExit, "invalid command name '%s'" % command[0m
[1m        self.commands.append(command)[0m
[1m    [0m
[1m        # Dig up the command class that implements this command, so we[0m
[1m        # 1) know that it's a valid command, and 2) know which options[0m
[1m        # it takes.[0m
[1m        try:[0m
[1m            cmd_class = self.get_command_class(command)[0m
[1m        except DistutilsModuleError, msg:[0m
[1m            raise DistutilsArgError, msg[0m
[1m    [0m
[1m        # Require that the command class be derived from Command -- want[0m
[1m        # to be sure that the basic "command" interface is implemented.[0m
[1m        if not issubclass(cmd_class, Command):[0m
[1m            raise DistutilsClassError, \[0m
[1m>                 "command class %s must subclass Command" % cmd_class[0m
[1m[31mE           DistutilsClassError: command class <class 'setuptools.command.build_ext.build_ext'> must subclass Command[0m

/home/travis/miniconda/lib/python2.7/distutils/dist.py:531: DistutilsClassError
____________________________ test_build_sphinx[cli] ____________________________

tmpdir = local('/tmp/pytest-0/test_build_sphinx_cli_0'), mode = 'cli'

[1m    @pytest.mark.parametrize('mode', ['cli', 'cli-w', 'direct'])[0m
[1m    def test_build_sphinx(tmpdir, mode):[0m
[1m        """[0m
[1m        Test for build_sphinx[0m
[1m        """[0m
[1m    [0m
[1m        import astropy_helpers[0m
[1m        ah_path = os.path.dirname(astropy_helpers.__file__)[0m
[1m    [0m
[1m        test_pkg = tmpdir.mkdir('test_pkg')[0m
[1m    [0m
[1m        test_pkg.mkdir('mypackage')[0m
[1m    [0m
[1m        test_pkg.join('mypackage').join('__init__.py').write(dedent("""\[0m
[1m            def test_function():[0m
[1m                pass[0m
[1m    [0m
[1m            class A():[0m
[1m                pass[0m
[1m    [0m
[1m            class B(A):[0m
[1m                pass[0m
[1m        """))[0m
[1m    [0m
[1m        docs = test_pkg.mkdir('docs')[0m
[1m    [0m
[1m        autosummary = docs.mkdir('_templates').mkdir('autosummary')[0m
[1m    [0m
[1m        autosummary.join('base.rst').write('{% extends "autosummary_core/base.rst" %}')[0m
[1m        autosummary.join('class.rst').write('{% extends "autosummary_core/class.rst" %}')[0m
[1m        autosummary.join('module.rst').write('{% extends "autosummary_core/module.rst" %}')[0m
[1m    [0m
[1m        docs_dir = test_pkg.join('docs')[0m
[1m    [0m
[1m        docs_dir.join('conf.py').write(dedent("""\[0m
[1m            import sys[0m
[1m            sys.path.append("../")[0m
[1m            import warnings[0m
[1m            with warnings.catch_warnings():  # ignore matplotlib warning[0m
[1m                warnings.simplefilter("ignore")[0m
[1m                from astropy_helpers.sphinx.conf import *[0m
[1m            exclude_patterns.append('_templates')[0m
[1m        """))[0m
[1m    [0m
[1m        docs_dir.join('index.rst').write(dedent("""\[0m
[1m            .. automodapi:: mypackage[0m
[1m        """))[0m
[1m    [0m
[1m        test_pkg.join('setup.py').write(dedent("""\[0m
[1m            from os.path import join[0m
[1m            from setuptools import setup, Extension[0m
[1m            from astropy_helpers.setup_helpers import register_commands, get_package_info[0m
[1m    [0m
[1m            NAME = 'mypackage'[0m
[1m            VERSION = 0.1[0m
[1m            RELEASE = True[0m
[1m    [0m
[1m            cmdclassd = register_commands(NAME, VERSION, RELEASE)[0m
[1m    [0m
[1m            setup([0m
[1m                name=NAME,[0m
[1m                version=VERSION,[0m
[1m                cmdclass=cmdclassd,[0m
[1m                **get_package_info()[0m
[1m            )[0m
[1m        """))[0m
[1m    [0m
[1m        with test_pkg.as_cwd():[0m
[1m            shutil.copytree(ah_path, 'astropy_helpers')[0m
[1m    [0m
[1m            if mode == 'cli':[0m
[1m>               run_setup('setup.py', ['build_sphinx'])[0m

/home/travis/build/astropy/astropy-helpers/astropy_helpers/tests/test_setup_helpers.py:191: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:204: in run_setup
[1m    raise[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:128: in save_modules
[1m    compat.reraise(new_cls, new_exc, tb)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:106: in save_modules
[1m    yield saved[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:201: in run_setup
[1m    DirectorySandbox(setup_dir).run(runner)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:231: in run
[1m    return func()[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:200: in runner
[1m    _execfile(setup_script, ns)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:46: in _execfile
[1m    exec(code, globals, locals)[0m
setup.py:15: in <module>
[1m    setup([0m
/home/travis/miniconda/lib/python2.7/distutils/core.py:137: in setup
[1m    ok = dist.parse_command_line()[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/dist.py:297: in parse_command_line
[1m    result = _Distribution.parse_command_line(self)[0m
/home/travis/miniconda/lib/python2.7/distutils/dist.py:467: in parse_command_line
[1m    args = self._parse_command_opts(parser, args)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/dist.py:599: in _parse_command_opts
[1m    nargs = _Distribution._parse_command_opts(self, parser, args)[0m
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <setuptools.dist.Distribution instance at 0x7f97877af050>
parser = <distutils.fancy_getopt.FancyGetopt instance at 0x7f97877af098>
args = ['build_sphinx']

[1m    def _parse_command_opts(self, parser, args):[0m
[1m        """Parse the command-line options for a single command.[0m
[1m            'parser' must be a FancyGetopt instance; 'args' must be the list[0m
[1m            of arguments, starting with the current command (whose options[0m
[1m            we are about to parse).  Returns a new version of 'args' with[0m
[1m            the next command at the front of the list; will be the empty[0m
[1m            list if there are no more commands on the command line.  Returns[0m
[1m            None if the user asked for help on this command.[0m
[1m            """[0m
[1m        # late import because of mutual dependence between these modules[0m
[1m        from distutils.cmd import Command[0m
[1m    [0m
[1m        # Pull the current command from the head of the command line[0m
[1m        command = args[0][0m
[1m        if not command_re.match(command):[0m
[1m            raise SystemExit, "invalid command name '%s'" % command[0m
[1m        self.commands.append(command)[0m
[1m    [0m
[1m        # Dig up the command class that implements this command, so we[0m
[1m        # 1) know that it's a valid command, and 2) know which options[0m
[1m        # it takes.[0m
[1m        try:[0m
[1m            cmd_class = self.get_command_class(command)[0m
[1m        except DistutilsModuleError, msg:[0m
[1m            raise DistutilsArgError, msg[0m
[1m    [0m
[1m        # Require that the command class be derived from Command -- want[0m
[1m        # to be sure that the basic "command" interface is implemented.[0m
[1m        if not issubclass(cmd_class, Command):[0m
[1m            raise DistutilsClassError, \[0m
[1m>                 "command class %s must subclass Command" % cmd_class[0m
[1m[31mE           DistutilsClassError: command class astropy_helpers.commands.build_sphinx.build_sphinx must subclass Command[0m

/home/travis/miniconda/lib/python2.7/distutils/dist.py:531: DistutilsClassError
----------------------------- Captured stderr call -----------------------------
/home/travis/miniconda/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'skip_2to3'
  warnings.warn(msg)
___________________________ test_build_sphinx[cli-w] ___________________________

tmpdir = local('/tmp/pytest-0/test_build_sphinx_cli_w_0'), mode = 'cli-w'

[1m    @pytest.mark.parametrize('mode', ['cli', 'cli-w', 'direct'])[0m
[1m    def test_build_sphinx(tmpdir, mode):[0m
[1m        """[0m
[1m        Test for build_sphinx[0m
[1m        """[0m
[1m    [0m
[1m        import astropy_helpers[0m
[1m        ah_path = os.path.dirname(astropy_helpers.__file__)[0m
[1m    [0m
[1m        test_pkg = tmpdir.mkdir('test_pkg')[0m
[1m    [0m
[1m        test_pkg.mkdir('mypackage')[0m
[1m    [0m
[1m        test_pkg.join('mypackage').join('__init__.py').write(dedent("""\[0m
[1m            def test_function():[0m
[1m                pass[0m
[1m    [0m
[1m            class A():[0m
[1m                pass[0m
[1m    [0m
[1m            class B(A):[0m
[1m                pass[0m
[1m        """))[0m
[1m    [0m
[1m        docs = test_pkg.mkdir('docs')[0m
[1m    [0m
[1m        autosummary = docs.mkdir('_templates').mkdir('autosummary')[0m
[1m    [0m
[1m        autosummary.join('base.rst').write('{% extends "autosummary_core/base.rst" %}')[0m
[1m        autosummary.join('class.rst').write('{% extends "autosummary_core/class.rst" %}')[0m
[1m        autosummary.join('module.rst').write('{% extends "autosummary_core/module.rst" %}')[0m
[1m    [0m
[1m        docs_dir = test_pkg.join('docs')[0m
[1m    [0m
[1m        docs_dir.join('conf.py').write(dedent("""\[0m
[1m            import sys[0m
[1m            sys.path.append("../")[0m
[1m            import warnings[0m
[1m            with warnings.catch_warnings():  # ignore matplotlib warning[0m
[1m                warnings.simplefilter("ignore")[0m
[1m                from astropy_helpers.sphinx.conf import *[0m
[1m            exclude_patterns.append('_templates')[0m
[1m        """))[0m
[1m    [0m
[1m        docs_dir.join('index.rst').write(dedent("""\[0m
[1m            .. automodapi:: mypackage[0m
[1m        """))[0m
[1m    [0m
[1m        test_pkg.join('setup.py').write(dedent("""\[0m
[1m            from os.path import join[0m
[1m            from setuptools import setup, Extension[0m
[1m            from astropy_helpers.setup_helpers import register_commands, get_package_info[0m
[1m    [0m
[1m            NAME = 'mypackage'[0m
[1m            VERSION = 0.1[0m
[1m            RELEASE = True[0m
[1m    [0m
[1m            cmdclassd = register_commands(NAME, VERSION, RELEASE)[0m
[1m    [0m
[1m            setup([0m
[1m                name=NAME,[0m
[1m                version=VERSION,[0m
[1m                cmdclass=cmdclassd,[0m
[1m                **get_package_info()[0m
[1m            )[0m
[1m        """))[0m
[1m    [0m
[1m        with test_pkg.as_cwd():[0m
[1m            shutil.copytree(ah_path, 'astropy_helpers')[0m
[1m    [0m
[1m            if mode == 'cli':[0m
[1m                run_setup('setup.py', ['build_sphinx'])[0m
[1m            elif mode == 'cli-w':[0m
[1m>               run_setup('setup.py', ['build_sphinx', '-w'])[0m

/home/travis/build/astropy/astropy-helpers/astropy_helpers/tests/test_setup_helpers.py:193: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:204: in run_setup
[1m    raise[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/contextlib.py:35: in __exit__
[1m    self.gen.throw(type, value, traceback)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:128: in save_modules
[1m    compat.reraise(new_cls, new_exc, tb)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:106: in save_modules
[1m    yield saved[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:157: in setup_context
[1m    yield[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:201: in run_setup
[1m    DirectorySandbox(setup_dir).run(runner)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:231: in run
[1m    return func()[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:200: in runner
[1m    _execfile(setup_script, ns)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/sandbox.py:46: in _execfile
[1m    exec(code, globals, locals)[0m
setup.py:15: in <module>
[1m    setup([0m
/home/travis/miniconda/lib/python2.7/distutils/core.py:137: in setup
[1m    ok = dist.parse_command_line()[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/dist.py:297: in parse_command_line
[1m    result = _Distribution.parse_command_line(self)[0m
/home/travis/miniconda/lib/python2.7/distutils/dist.py:467: in parse_command_line
[1m    args = self._parse_command_opts(parser, args)[0m
/home/travis/miniconda/lib/python2.7/site-packages/setuptools-11.3.1-py2.7.egg/setuptools/dist.py:599: in _parse_command_opts
[1m    nargs = _Distribution._parse_command_opts(self, parser, args)[0m
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <setuptools.dist.Distribution instance at 0x7f9786ae3290>
parser = <distutils.fancy_getopt.FancyGetopt instance at 0x7f9786ae3488>
args = ['build_sphinx', '-w']

[1m    def _parse_command_opts(self, parser, args):[0m
[1m        """Parse the command-line options for a single command.[0m
[1m            'parser' must be a FancyGetopt instance; 'args' must be the list[0m
[1m            of arguments, starting with the current command (whose options[0m
[1m            we are about to parse).  Returns a new version of 'args' with[0m
[1m            the next command at the front of the list; will be the empty[0m
[1m            list if there are no more commands on the command line.  Returns[0m
[1m            None if the user asked for help on this command.[0m
[1m            """[0m
[1m        # late import because of mutual dependence between these modules[0m
[1m        from distutils.cmd import Command[0m
[1m    [0m
[1m        # Pull the current command from the head of the command line[0m
[1m        command = args[0][0m
[1m        if not command_re.match(command):[0m
[1m            raise SystemExit, "invalid command name '%s'" % command[0m
[1m        self.commands.append(command)[0m
[1m    [0m
[1m        # Dig up the command class that implements this command, so we[0m
[1m        # 1) know that it's a valid command, and 2) know which options[0m
[1m        # it takes.[0m
[1m        try:[0m
[1m            cmd_class = self.get_command_class(command)[0m
[1m        except DistutilsModuleError, msg:[0m
[1m            raise DistutilsArgError, msg[0m
[1m    [0m
[1m        # Require that the command class be derived from Command -- want[0m
[1m        # to be sure that the basic "command" interface is implemented.[0m
[1m        if not issubclass(cmd_class, Command):[0m
[1m            raise DistutilsClassError, \[0m
[1m>                 "command class %s must subclass Command" % cmd_class[0m
[1m[31mE           DistutilsClassError: command class astropy_helpers.commands.build_sphinx.build_sphinx must subclass Command[0m

/home/travis/miniconda/lib/python2.7/distutils/dist.py:531: DistutilsClassError
----------------------------- Captured stderr call -----------------------------
/home/travis/miniconda/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'skip_2to3'
  warnings.warn(msg)
```

Looks like most of these were introduced in  ``setuptools==10``.
