### PR TITLE
Deprecate AstropyAutosummary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,11 @@ astropy-helpers Changelog
   defined in.  But please consider updating any imports to these objects.
   [#110]
 
+- Use of the ``astropy.sphinx.ext.astropyautosummary`` extension is deprecated
+  for use with Sphinx < 1.2.  Instead it should suffice to remove this
+  extension for the ``extensions`` list in your ``conf.py`` and add the stock
+  ``sphinx.ext.autosummary`` instead. [#131]
+
 
 0.4.5 (unreleased)
 ------------------

--- a/astropy_helpers/sphinx/ext/astropyautosummary.py
+++ b/astropy_helpers/sphinx/ext/astropyautosummary.py
@@ -6,15 +6,27 @@ clean up some issues it presents in the Astropy docs.
 The main issue this fixes is the summary tables getting cut off before the
 end of the sentence in some cases.
 
+Note: Sphinx 1.2 appears to have fixed the the main issues in the stock
+autosummary extension that are addressed by this extension.  So use of this
+extension with newer versions of Sphinx is deprecated.
 """
+
 import re
 
+from distutils.version import LooseVersion
+
+import sphinx
+
 from sphinx.ext.autosummary import Autosummary
+
+from ...utils import deprecated
 
 # used in AstropyAutosummary.get_items
 _itemsummrex = re.compile(r'^([A-Z].*?\.(?:\s|$))')
 
 
+@deprecated('1.0', message='AstropyAutosummary is only needed when used '
+                           'with Sphinx versions less than 1.2')
 class AstropyAutosummary(Autosummary):
     def get_items(self, names):
         """Try to import the given names, and return a list of
@@ -94,5 +106,8 @@ class AstropyAutosummary(Autosummary):
 def setup(app):
     # need autosummary, of course
     app.setup_extension('sphinx.ext.autosummary')
-    # this replaces the default autosummary with the astropy one
-    app.add_directive('autosummary', AstropyAutosummary)
+
+    # Don't make the replacement if Sphinx is at least 1.2
+    if LooseVersion(sphinx.__version__) < LooseVersion('1.2.0'):
+        # this replaces the default autosummary with the astropy one
+        app.add_directive('autosummary', AstropyAutosummary)

--- a/astropy_helpers/sphinx/ext/automodsumm.py
+++ b/astropy_helpers/sphinx/ext/automodsumm.py
@@ -81,12 +81,23 @@ import inspect
 import os
 import re
 
+from distutils.version import LooseVersion
+
+import sphinx
 from sphinx.ext.autosummary import Autosummary
 from sphinx.ext.inheritance_diagram import InheritanceDiagram
 from docutils.parsers.rst.directives import flag
 
 from .utils import find_mod_objs
 from .astropyautosummary import AstropyAutosummary
+
+
+# Don't use AstropyAutosummary with newer versions of Sphinx
+# See https://github.com/astropy/astropy-helpers/pull/129
+if LooseVersion(sphinx.__version__) < LooseVersion('1.2.0'):
+    BaseAutosummary = AstropyAutosummary
+else:
+    BaseAutosummary = Autosummary
 
 
 def _str_list_converter(argument):
@@ -100,7 +111,7 @@ def _str_list_converter(argument):
         return [s.strip() for s in argument.split(',')]
 
 
-class Automodsumm(AstropyAutosummary):
+class Automodsumm(BaseAutosummary):
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = False
@@ -426,7 +437,7 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
             name, obj, parent = import_by_name_values
         elif len(import_by_name_values) == 4:
             name, obj, parent, module_name = import_by_name_values
-        
+
         fn = os.path.join(path, name + suffix)
 
         # skip it if it exists


### PR DESCRIPTION
As discussed in #116, this drops use of the `AstropyAutosummary` class in Sphinx < 1.2, and emits a warning if it is deprecated.  This warning will only occur if the extension is being used in Sphinx < 1.2, so it should serve also as a warning to update to a new Sphinx version.  I don't think this will affect many users, if any.

At a later stage I will mark the entire astropyautosummary extension as deprecated, and it can just be removed in favor of the stock `sphinx.ext.autosummary`.