### PR TITLE
Merge pull request #139 from embray/fix-compiler-issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ astropy-helpers Changelog
 0.4.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed problems related to the automatically generated _compiler
+  module not being created properly. [#139]
 
 
 0.4.5 (2015-02-11)

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -482,14 +482,18 @@ def generate_build_ext_command(packagename, release):
         # Add a copy of the _compiler.so module as well, but only if there are
         # in fact C modules to compile (otherwise there's no reason to include
         # a record of the compiler used)
-        if self.extensions:
+        # Note, self.extensions may not be set yet, but
+        # self.distribution.ext_modules is where any extension modules passed
+        # to setup() can be found
+        extensions = self.distribution.ext_modules
+        if extensions:
             src_path = os.path.relpath(
                 os.path.join(os.path.dirname(__file__), 'src'))
             shutil.copy2(os.path.join(src_path, 'compiler.c'),
                          os.path.join(self.package_name, '_compiler.c'))
             ext = Extension(self.package_name + '._compiler',
                             [os.path.join(self.package_name, '_compiler.c')])
-            self.extensions.insert(0, ext)
+            extensions.insert(0, ext)
 
         if orig_finalize is not None:
             orig_finalize(self)

--- a/astropy_helpers/setup_package.py
+++ b/astropy_helpers/setup_package.py
@@ -1,0 +1,4 @@
+from os.path import join
+
+def get_package_data():
+    return {'astropy_helpers': [join('src', 'compiler.c')]}

--- a/astropy_helpers/src/setup_package.py
+++ b/astropy_helpers/src/setup_package.py
@@ -1,2 +1,0 @@
-def get_package_data():
-    return {'astropy_helpers.src': ['compiler.c']}


### PR DESCRIPTION
Fixes to the auto-generated _compiler module
Conflicts:
	astropy_helpers/commands/build_ext.py
	astropy_helpers/tests/test_setup_helpers.py


Creating a separate pull request for the backport of this into the v0.4.x branch since it required a few modifications (all tests passed locally, but I would to be double-sure).