### PR TITLE
githash = 'None' when running generate_version_py for the first time with uses_get=False

### DIFF
--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -35,7 +35,7 @@ from astropy_helpers.version_helpers import generate_version_py
 if not RELEASE:
     VERSION += get_git_devstr(False)
 
-generate_version_py(NAME, VERSION, RELEASE, False)
+generate_version_py(NAME, VERSION, RELEASE, False, uses_git=not RELEASE)
 
 setup(name=NAME, version=VERSION, packages=['_eva_'])
 """
@@ -51,27 +51,30 @@ except ImportError:
 
 
 @pytest.fixture
-def version_test_package(tmpdir, request, version='42.42.dev'):
-    test_package = tmpdir.mkdir('test_package')
-    test_package.join('setup.py').write(
-        TEST_VERSION_SETUP_PY.format(version=version))
-    test_package.mkdir('_eva_').join('__init__.py').write(TEST_VERSION_INIT)
-    with test_package.as_cwd():
-        run_cmd('git', ['init'])
-        run_cmd('git', ['add', '--all'])
-        run_cmd('git', ['commit', '-m', 'test package'])
+def version_test_package(tmpdir, request):
+    def make_test_package(version='42.42.dev'):
+        test_package = tmpdir.mkdir('test_package')
+        test_package.join('setup.py').write(
+            TEST_VERSION_SETUP_PY.format(version=version))
+        test_package.mkdir('_eva_').join('__init__.py').write(TEST_VERSION_INIT)
+        with test_package.as_cwd():
+            run_cmd('git', ['init'])
+            run_cmd('git', ['add', '--all'])
+            run_cmd('git', ['commit', '-m', 'test package'])
 
-    if '' in sys.path:
-        sys.path.remove('')
+        if '' in sys.path:
+            sys.path.remove('')
 
-    sys.path.insert(0, '')
+        sys.path.insert(0, '')
 
-    def finalize():
-        cleanup_import('_eva_')
+        def finalize():
+            cleanup_import('_eva_')
 
-    request.addfinalizer(finalize)
+        request.addfinalizer(finalize)
 
-    return test_package
+        return test_package
+
+    return make_test_package
 
 
 def test_update_git_devstr(version_test_package, capsys):
@@ -79,7 +82,10 @@ def test_update_git_devstr(version_test_package, capsys):
     after git commits even without re-running setup.py.
     """
 
-    with version_test_package.as_cwd():
+    # We have to call version_test_package to actually create the package
+    test_pkg = version_test_package()
+
+    with test_pkg.as_cwd():
         run_setup('setup.py', ['--version'])
 
         stdout, stderr = capsys.readouterr()
@@ -119,7 +125,7 @@ def test_update_git_devstr(version_test_package, capsys):
     # directly and compare to the value in packagename
     from astropy_helpers.git_helpers import update_git_devstr
 
-    newversion = update_git_devstr(version, path=str(version_test_package))
+    newversion = update_git_devstr(version, path=str(test_pkg))
     assert newversion == _eva_.version.version
 
 
@@ -129,11 +135,13 @@ def test_version_update_in_other_repos(version_test_package, tmpdir):
     and for https://github.com/astropy/astropy-helpers/issues/107
     """
 
-    with version_test_package.as_cwd():
+    test_pkg = version_test_package()
+
+    with test_pkg.as_cwd():
         run_setup('setup.py', ['build'])
 
     # Add the path to the test package to sys.path for now
-    sys.path.insert(0, str(version_test_package))
+    sys.path.insert(0, str(test_pkg))
     try:
         import _eva_
         m = _DEV_VERSION_RE.match(_eva_.__version__)
@@ -167,10 +175,11 @@ def test_version_update_in_other_repos(version_test_package, tmpdir):
             assert int(m.group(1)) == correct_revcount
             correct_revcount = int(m.group(1))
     finally:
-        sys.path.remove(str(version_test_package))
+        sys.path.remove(str(test_pkg))
 
 
-def test_installed_git_version(version_test_package, tmpdir, capsys):
+@pytest.mark.parametrize('version', ['1.0.dev', '1.0'])
+def test_installed_git_version(version_test_package, version, tmpdir, capsys):
     """
     Test for https://github.com/astropy/astropy-helpers/issues/87
 
@@ -182,13 +191,18 @@ def test_installed_git_version(version_test_package, tmpdir, capsys):
     # somewhere outside the git repository, and then do a build and import
     # from the build directory--no need to "install" as such
 
-    with version_test_package.as_cwd():
+    test_pkg = version_test_package(version)
+
+    with test_pkg.as_cwd():
         run_setup('setup.py', ['build'])
 
         try:
             import _eva_
             githash = _eva_.__githash__
             assert githash and isinstance(githash, _text_type)
+            # Ensure that it does in fact look like a git hash and not some
+            # other arbitrary string
+            assert re.match(r'[0-9a-f]{40}', githash)
         finally:
             cleanup_import('_eva_')
 
@@ -197,7 +211,7 @@ def test_installed_git_version(version_test_package, tmpdir, capsys):
         tgzs = glob.glob(os.path.join('dist', '*.tar.gz'))
         assert len(tgzs) == 1
 
-        tgz = version_test_package.join(tgzs[0])
+        tgz = test_pkg.join(tgzs[0])
 
     build_dir = tmpdir.mkdir('build_dir')
     tf = tarfile.open(str(tgz), mode='r:gz')

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -155,6 +155,12 @@ def _get_version_py_str(packagename, version, githash, release, debug,
 
     if uses_git:
         header = _generate_git_header(packagename, version, githash)
+    elif not githash:
+        # _generate_git_header will already generate a new git has for us, but
+        # for creating a new version.py for a release (even if uses_git=False)
+        # we still need to get the githash to include in the version.py
+        # See https://github.com/astropy/astropy-helpers/issues/141
+        githash = git_helpers.get_git_devstr(sha=True, show_warning=True)
 
     if not header:  # If _generate_git_header fails it returns an empty string
         header = _FROZEN_VERSION_PY_STATIC_HEADER.format(verstr=version,
@@ -227,7 +233,7 @@ def generate_version_py(packagename, version, release=None, debug=None,
         try:
             last_githash = version_module._last_githash
         except AttributeError:
-            last_githash = ''
+            last_githash = version_module.githash
 
         current_release = version_module.release
         current_debug = version_module.debug


### PR DESCRIPTION
(I could have sworn I submitted this yesterday, but it seems to have vanished...)

The behavior when running `generate_version_py` with the `uses_git=False` flag isn't quite right.  This flag should *not* mean that git should not be used at all to generate the `version.py` module.  Rather, it just means that the generated `version.py` itself should be the "static" version that does not contain any code that runs git.

This means that in a fresh checkout of a release version of Astropy, running `setup.py` for the first time results in a `version.py` that contains `githash = 'None'` because it won't run git to determine the latest commit hash.  I got around this while making the Astropy v0.4.5 release by manually running `generate_version_py` once with `uses_git=True`, and then running it again with `uses_git=False`.  

Relatedly, I feel that running `generate_version_py` out of a release version, when a `version.py` already exists, should be a no-op.  It should not generate a newer `version.py` than the one that was bundled with the release.