### PR TITLE
Added instructions for OTF download from PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 astropy-helpers
 ===============
 
+About
+-----
+
 This project provides a Python package, ``astropy_helpers``, which includes
 many build, installation, and documentation-related tools used by the Astropy
 project, but packaged separately for use by other projects that wish to
@@ -21,9 +24,31 @@ corresponding major/minor version of the `astropy core package
 version numbers. Hence, the initial release is 0.4, in parallel with Astropy
 v0.4, which will be the first version  of Astropy to use ``astropy-helpers``.
 
-For examples of how to implement ``astropy-helpers`` in a project,
-see the ``setup.py`` and ``setup.cfg`` files of the 
-`Affiliated package template <https://github.com/astropy/package-template>`_.
+Getting started
+---------------
+
+Note that the ``astropy-helpers`` is not intended to be installed as a normal package. There are several ways to make use of it, which are described below.
+
+As a submodule
+^^^^^^^^^^^^^^
+
+The `Affiliated package template <https://github.com/astropy/package-template>`_ provides a complete example of how to include the astropy-helpers module as a submodule.
+
+From PyPI
+^^^^^^^^^
+
+In some simpler cases, you may only want to make use of ``astropy-helpers``
+within the scope of a single script - for example you may want to use the
+Sphinx extensions in ``astropy-helpers`` within a Sphinx ``conf.py`` file. In
+this case, you can simply add the following two lines at the top of your
+script::
+
+    from setuptools import Distribution
+    Distribution({'setup_requires': 'astropy-helpers'})
+    
+This will download the ``astropy-helpers`` package from PyPI on-the-fly and
+include it in a hidden ``.eggs`` directory, and the ``astropy-helpers`` module
+can then be imported anywhere in the remainder of the script.
 
 .. image:: https://travis-ci.org/astropy/astropy-helpers.png
     :target: https://travis-ci.org/astropy/astropy-helpers


### PR DESCRIPTION
In glue, we want to make use of astropy-helpers only for the Sphinx extensions, so including it as a submodule is overkill. In that case, it's enough to simply include:

```python
from setuptools import Distribution
Distribution({'setup_requires': 'astropy-helpers'})
```

at the top of the ``conf.py`` script and it will get downloaded from ``PyPI`` and installed into a temporary local directory. This PR adds instructions related to this to the README.

@embray - maybe you can comment on whether there is a better way to do this?

The glue PR is here: https://github.com/glue-viz/glue/pull/566