### PR TITLE
Allow astropy-helpers to override itself

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,20 @@ astropy-helpers Changelog
 - Nothing changed yet.
 
 
+1.0.1 (unreleased)
+------------------
+
+- Improved the ``ah_bootstrap`` script's ability to override existing
+  installations of astropy-helpers with new versions in the context of
+  installing multiple packages simultaneously within the same Python
+  interpreter (e.g. when one package has in its ``setup_requires`` another
+  package that uses a different version of astropy-helpers. [#144]
+
+- Added a workaround to an issue in matplotlib that can, in rare cases, lead
+  to a crash when installing packages that import matplotlib at build time.
+  [#144]
+
+
 1.0 (2015-02-17)
 ----------------
 

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -56,6 +56,12 @@ else:
     _text_type = str
     PY3 = True
 
+
+# What follows are several import statements meant to deal with install-time
+# issues with either missing or misbehaving pacakges (including making sure
+# setuptools itself is installed):
+
+
 # Some pre-setuptools checks to ensure that either distribute or setuptools >=
 # 0.7 is used (over pre-distribute setuptools) if it is available on the path;
 # otherwise the latest setuptools will be downloaded and bootstrapped with
@@ -84,16 +90,6 @@ except:
     from ez_setup import use_setuptools
     use_setuptools()
 
-from distutils import log
-from distutils.debug import DEBUG
-
-
-# In case it didn't successfully import before the ez_setup checks
-import pkg_resources
-
-from setuptools import Distribution
-from setuptools.package_index import PackageIndex
-from setuptools.sandbox import run_setup
 
 # Note: The following import is required as a workaround to
 # https://github.com/astropy/astropy-helpers/issues/89; if we don't import this
@@ -104,6 +100,35 @@ try:
     import setuptools.py31compat
 except ImportError:
     pass
+
+
+# matplotlib can cause problems if it is imported from within a call of
+# run_setup(), because in some circumstances it will try to write to the user's
+# home directory, resulting in a SandboxViolation.  See
+# https://github.com/matplotlib/matplotlib/pull/4165
+# Making sure matplotlib, if it is available, is imported early in the setup
+# process can mitigate this (note importing matplotlib.pyplot has the same
+# issue)
+try:
+    import matplotlib.pyplot
+except:
+    # Ignore if this fails for *any* reason*
+    pass
+
+
+# End compatibility imports...
+
+
+# In case it didn't successfully import before the ez_setup checks
+import pkg_resources
+
+from setuptools import Distribution
+from setuptools.package_index import PackageIndex
+from setuptools.sandbox import run_setup
+
+from distutils import log
+from distutils.debug import DEBUG
+
 
 # TODO: Maybe enable checking for a specific version of astropy_helpers?
 DIST_NAME = 'astropy-helpers'

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -314,8 +314,13 @@ class _Bootstrapper(object):
         # package's installer is installing another package via
         # setuptools.sandbox.run_set, as in the case of setup_requires
         for key in list(sys.modules):
-            if key == PACKAGE_NAME or key.startswith(PACKAGE_NAME + '.'):
-                del sys.modules[key]
+            try:
+                if key == PACKAGE_NAME or key.startswith(PACKAGE_NAME + '.'):
+                    del sys.modules[key]
+            except AttributeError:
+                # Sometimes mysterious non-string things can turn up in
+                # sys.modules
+                continue
 
         try:
             pkg_resources.working_set.add(dist, replace=True)

--- a/astropy_helpers/__init__.py
+++ b/astropy_helpers/__init__.py
@@ -4,3 +4,13 @@ try:
 except ImportError:
     __version__ = ''
     __githash__ = ''
+
+
+# If we've made it as far as importing astropy_helpers, we don't need
+# ah_bootstrap in sys.modules anymore.  Getting rid of it is actually necessary
+# if the package we're installing has a setup_requires of another package that
+# uses astropy_helpers (and possibly a different version at that)
+# See https://github.com/astropy/astropy/issues/3541
+import sys
+if 'ah_bootstrap' in sys.modules:
+    del sys.modules['ah_bootstrap']

--- a/astropy_helpers/__init__.py
+++ b/astropy_helpers/__init__.py
@@ -14,3 +14,20 @@ except ImportError:
 import sys
 if 'ah_bootstrap' in sys.modules:
     del sys.modules['ah_bootstrap']
+
+
+# Note, this is repeated from ah_bootstrap.py, but is here too in case this
+# astropy-helpers was upgraded to from an older version that did not have this
+# check in its ah_bootstrap.
+# matplotlib can cause problems if it is imported from within a call of
+# run_setup(), because in some circumstances it will try to write to the user's
+# home directory, resulting in a SandboxViolation.  See
+# https://github.com/matplotlib/matplotlib/pull/4165
+# Making sure matplotlib, if it is available, is imported early in the setup
+# process can mitigate this (note importing matplotlib.pyplot has the same
+# issue)
+try:
+    import matplotlib.pyplot
+except:
+    # Ignore if this fails for *any* reason*
+    pass


### PR DESCRIPTION
This should provide a workaround for astropy/astropy#3541

I haven't written a test for this yet, though it would be a relatively difficult one (not impossible though so I may try to add one later).  In the meantime I'm going to test this directly using testpypi.

In order for this change to fully fix astropy/astropy#3541 there will need to be two new releases of astropy-helpers: v0.4.8, and v1.0.1 each of which will include this fix.  When installing poppy, webbpsf, or any other similar affiliated package that has not yet updated to astropy-helpers 1.0 *and* that lists astropy in `setup_requires`, the ah_bootstrap will auto-upgrade astropy-helpers to v0.4.8.  This will include the necessary logic required so that when it in turn tries to install astropy, astropy's *own* ah_bootstrap can run, upgrade itself to astropy-helpers v1.0.1, and carry on with the installation.