### PR TITLE
sphinx.ext.automodsumm broken with Sphinx 1.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ astropy-helpers Changelog
   logo and linkout image, falling back to PNGs for browsers that
   support it. [#151]
 
+- Various fixes enabling the astropy-helpers Sphinx build command and
+  Sphinx extensions to work with Sphinx 1.3. [#148]
+
 
 1.0.1 (2015-03-04)
 ------------------

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -10,7 +10,10 @@ import textwrap
 from distutils import log
 from distutils.cmd import DistutilsOptionError
 
+import sphinx
 from sphinx.setup_command import BuildDoc as SphinxBuildDoc
+
+from ..utils import minversion
 
 
 PY3 = sys.version_info[0] >= 3
@@ -145,6 +148,12 @@ class AstropyBuildSphinx(SphinxBuildDoc):
             else:
                 subproccode[i] = repr(val)
         subproccode = ''.join(subproccode)
+
+        # This is a quick gross hack, but it ensures that the code grabbed from
+        # SphinxBuildDoc.run will work in Python 2 if it uses the print
+        # function
+        if minversion(sphinx, '1.3'):
+            subproccode = 'from __future__ import print_function' + subproccode
 
         if self.no_intersphinx:
             # the confoverrides variable in sphinx.setup_command.BuildDoc can

--- a/astropy_helpers/sphinx/ext/autodoc_enhancements.py
+++ b/astropy_helpers/sphinx/ext/autodoc_enhancements.py
@@ -43,13 +43,16 @@ def type_object_attrgetter(obj, attr, *defargs):
     of autodoc.
     """
 
-    if attr in obj.__dict__ and isinstance(obj.__dict__[attr], property):
-        # Note, this should only be used for properties--for any other type of
-        # descriptor (classmethod, for example) this can mess up existing
-        # expectcations of what getattr(cls, ...) returns
-        return obj.__dict__[attr]
-    else:
-        return getattr(obj, attr, *defargs)
+    for base in obj.__mro__:
+        if attr in base.__dict__:
+            if isinstance(base.__dict__[attr], property):
+                # Note, this should only be used for properties--for any other
+                # type of descriptor (classmethod, for example) this can mess
+                # up existing expectations of what getattr(cls, ...) returns
+                return base.__dict__[attr]
+            break
+
+    return getattr(obj, attr, *defargs)
 
 
 def setup(app):

--- a/astropy_helpers/sphinx/ext/automodapi.py
+++ b/astropy_helpers/sphinx/ext/automodapi.py
@@ -171,6 +171,8 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
         sphinx markup.
     """
 
+    env = app.builder.env
+
     spl = _automodapirex.split(sourcestr)
     if len(spl) > 1:  # automodsumm is in this document
 
@@ -311,7 +313,12 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                     f.write('\n**NEW DOC**\n\n')
                     f.write(ustr)
             else:
-                with open(os.path.join(app.srcdir, docname + '.automodapi'), 'w') as f:
+                # Determine the filename associated with this doc (specifically
+                # the extension)
+                filename = docname + os.path.splitext(env.doc2path(docname))[1]
+                filename += '.automodapi'
+
+                with open(os.path.join(app.srcdir, filename), 'w') as f:
                     f.write(ustr)
 
         return newsourcestr

--- a/astropy_helpers/sphinx/ext/automodapi.py
+++ b/astropy_helpers/sphinx/ext/automodapi.py
@@ -171,8 +171,6 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
         sphinx markup.
     """
 
-    env = app.builder.env
-
     spl = _automodapirex.split(sourcestr)
     if len(spl) > 1:  # automodsumm is in this document
 
@@ -313,6 +311,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                     f.write('\n**NEW DOC**\n\n')
                     f.write(ustr)
             else:
+                env = app.builder.env
                 # Determine the filename associated with this doc (specifically
                 # the extension)
                 filename = docname + os.path.splitext(env.doc2path(docname))[1]

--- a/astropy_helpers/sphinx/ext/automodapi.py
+++ b/astropy_helpers/sphinx/ext/automodapi.py
@@ -85,6 +85,11 @@ import sys
 
 from .utils import find_mod_objs
 
+if sys.version_info[0] == 3:
+    text_type = str
+else:
+    text_type = unicode
+
 
 automod_templ_modheader = """
 {modname} {pkgormod}
@@ -296,7 +301,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
         if app.config.automodapi_writereprocessed:
             # sometimes they are unicode, sometimes not, depending on how
             # sphinx has processed things
-            if isinstance(newsourcestr, unicode):
+            if isinstance(newsourcestr, text_type):
                 ustr = newsourcestr
             else:
                 ustr = newsourcestr.decode(app.config.source_encoding)
@@ -304,10 +309,10 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
             if docname is None:
                 with open(os.path.join(app.srcdir, 'unknown.automodapi'), 'a') as f:
                     f.write('\n**NEW DOC**\n\n')
-                    f.write(ustr.encode('utf8'))
+                    f.write(ustr)
             else:
                 with open(os.path.join(app.srcdir, docname + '.automodapi'), 'w') as f:
-                    f.write(ustr.encode('utf8'))
+                    f.write(ustr)
 
         return newsourcestr
     else:
@@ -330,8 +335,11 @@ def _mod_info(modname, toskip=[], onlylocals=True):
                 break
 
     # find_mod_objs has already imported modname
+    # TODO: There is probably a cleaner way to do this, though this is pretty
+    # reliable for all Python versions for most cases that we care about.
     pkg = sys.modules[modname]
-    ispkg = '__init__.' in os.path.split(pkg.__name__)[1]
+    ispkg = (hasattr(pkg, '__file__') and isinstance(pkg.__file__, str) and
+             os.path.split(pkg.__file__)[1].startswith('__init__.py'))
 
     return ispkg, hascls, hasfunc
 

--- a/astropy_helpers/sphinx/ext/automodsumm.py
+++ b/astropy_helpers/sphinx/ext/automodsumm.py
@@ -220,10 +220,12 @@ class Automoddiagram(InheritanceDiagram):
 #<---------------------automodsumm generation stuff--------------------------->
 def process_automodsumm_generation(app):
     env = app.builder.env
-    ext = app.config.source_suffix
 
-    filestosearch = [x + ext for x in env.found_docs
-                     if os.path.isfile(env.doc2path(x))]\
+    filestosearch = []
+    for docname in env.found_docs:
+        filename = env.doc2path(docname)
+        if os.path.isfile(filename):
+            filestosearch.append(docname + os.path.splitext(filename)[1])
 
     liness = []
     for sfn in filestosearch:
@@ -238,10 +240,11 @@ def process_automodsumm_generation(app):
                         f.write('\n')
 
     for sfn, lines in zip(filestosearch, liness):
+        suffix = os.path.splitext(sfn)[1]
         if len(lines) > 0:
             generate_automodsumm_docs(lines, sfn, builder=app.builder,
                                       warn=app.warn, info=app.info,
-                                      suffix=app.config.source_suffix,
+                                      suffix=suffix,
                                       base_path=app.srcdir)
 
 #_automodsummrex = re.compile(r'^(\s*)\.\. automodsumm::\s*([A-Za-z0-9_.]+)\s*'
@@ -281,6 +284,7 @@ def automodsumm_to_autosummary_lines(fn, app):
 
 
     """
+
     fullfn = os.path.join(app.builder.env.srcdir, fn)
 
     with open(fullfn) as fr:
@@ -288,7 +292,8 @@ def automodsumm_to_autosummary_lines(fn, app):
             from astropy_helpers.sphinx.ext.automodapi import automodapi_replace
             # Must do the automodapi on the source to get the automodsumm
             # that might be in there
-            filestr = automodapi_replace(fr.read(), app, True, fn, False)
+            docname = os.path.splitext(fn)[0]
+            filestr = automodapi_replace(fr.read(), app, True, docname, False)
         else:
             filestr = fr.read()
 
@@ -352,6 +357,9 @@ def automodsumm_to_autosummary_lines(fn, app):
             if clssonly and not inspect.isclass(obj):
                 continue
             newlines.append(allindent + nm)
+
+    # add one newline at the end of the autosummary block
+    newlines.append('')
 
     return newlines
 

--- a/astropy_helpers/sphinx/ext/automodsumm.py
+++ b/astropy_helpers/sphinx/ext/automodsumm.py
@@ -172,17 +172,22 @@ class Automodsumm(BaseAutosummary):
 
             self.content = cont
 
-            #for some reason, even though ``currentmodule`` is substituted in, sphinx
-            #doesn't necessarily recognize this fact.  So we just force it
-            #internally, and that seems to fix things
+            # for some reason, even though ``currentmodule`` is substituted in,
+            # sphinx doesn't necessarily recognize this fact.  So we just force
+            # it internally, and that seems to fix things
             env.temp_data['py:module'] = modname
 
-            #can't use super because Sphinx/docutils has trouble
-            #return super(Autosummary,self).run()
+            # can't use super because Sphinx/docutils has trouble return
+            # super(Autosummary,self).run()
             nodelist.extend(Autosummary.run(self))
+
             return self.warnings + nodelist
         finally:  # has_content = False for the Automodsumm
             self.content = []
+
+    def get_items(self, names):
+        self.genopt['imported-members'] = True
+        return Autosummary.get_items(self, names)
 
 
 #<-------------------automod-diagram stuff------------------------------------>

--- a/astropy_helpers/sphinx/ext/tests/test_automodsumm.py
+++ b/astropy_helpers/sphinx/ext/tests/test_automodsumm.py
@@ -66,7 +66,8 @@ ams_to_asmry_expected = """\
     automodsumm_to_autosummary_lines
     generate_automodsumm_docs
     process_automodsumm_generation
-    setup"""
+    setup
+"""
 
 
 def test_ams_to_asmry(tmpdir):
@@ -97,7 +98,8 @@ ams_cython_expected = """\
 .. autosummary::
     :p:
 
-    pilot"""
+    pilot
+"""
 
 
 def test_ams_cython(tmpdir, cython_testpackage):

--- a/astropy_helpers/sphinx/ext/viewcode.py
+++ b/astropy_helpers/sphinx/ext/viewcode.py
@@ -16,6 +16,7 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx.locale import _
 from sphinx.pycode import ModuleAnalyzer
+from sphinx.util.inspect import safe_getattr
 from sphinx.util.nodes import make_refnode
 
 import sys
@@ -51,12 +52,12 @@ def doctree_read(app, doctree):
             value = module
             for attr in attribute.split('.'):
                 if attr:
-                    value = getattr(value, attr)
+                    value = safe_getattr(value, attr)
         except AttributeError:
             app.warn('Didn\'t find %s in %s' % (attribute, module.__name__))
             return None
         else:
-            return getattr(value, '__module__', None)
+            return safe_getattr(value, '__module__', None)
 
 
     def has_tag(modname, fullname, docname, refname):


### PR DESCRIPTION
After updating to Sphinx 1.3 the Sphinx build for Astropy and all affiliated packages doesn't work any more!?
```
$ python setup.py build_sphinx
...
Traceback (most recent call last):
  File "<stdin>", line 28, in <module>
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 188, in __init__
    self._init_builder(buildername)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 250, in _init_builder
    self.emit('builder-inited')
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/sphinx/application.py", line 497, in emit
    results.append(callback(self, *args))
  File "/Users/deil/code/astropy/astropy_helpers/astropy_helpers/sphinx/ext/automodsumm.py", line 225, in process_automodsumm_generation
    filestosearch = [x + ext for x in env.found_docs
  File "/Users/deil/code/astropy/astropy_helpers/astropy_helpers/sphinx/ext/automodsumm.py", line 226, in <listcomp>
    if os.path.isfile(env.doc2path(x))]\
TypeError: Can't convert 'list' object to str implicitly
```
cc @eteq @astrofrog