### PR TITLE
auto-upgrade can break when a previous install of a different package *also* auto-upgraded astropy-helpers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ astropy-helpers Changelog
 - Various fixes enabling the astropy-helpers Sphinx build command and
   Sphinx extensions to work with Sphinx 1.3. [#148]
 
+- More improvement to the ability to handle multiple versions of
+  astropy-helpers being imported in the same Python interpreter session
+  in the (somewhat rare) case of nested installs. [#147]
+
 
 1.0.1 (2015-03-04)
 ------------------

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -282,6 +282,19 @@ class _Bootstrapper(object):
         strategies = ['local_directory', 'local_file', 'index']
         dist = None
 
+        # First, remove any previously imported versions of astropy_helpers;
+        # this is necessary for nested installs where one package's installer
+        # is installing another package via setuptools.sandbox.run_setup, as in
+        # the case of setup_requires
+        for key in list(sys.modules):
+            try:
+                if key == PACKAGE_NAME or key.startswith(PACKAGE_NAME + '.'):
+                    del sys.modules[key]
+            except AttributeError:
+                # Sometimes mysterious non-string things can turn up in
+                # sys.modules
+                continue
+
         # Check to see if the path is a submodule
         self.is_submodule = self._check_submodule()
 
@@ -310,19 +323,6 @@ class _Bootstrapper(object):
         # do it again
         # Note: Adding the dist to the global working set also activates it
         # (makes it importable on sys.path) by default.
-
-        # But first, remove any previously imported versions of
-        # astropy_helpers; this is necessary for nested installs where one
-        # package's installer is installing another package via
-        # setuptools.sandbox.run_set, as in the case of setup_requires
-        for key in list(sys.modules):
-            try:
-                if key == PACKAGE_NAME or key.startswith(PACKAGE_NAME + '.'):
-                    del sys.modules[key]
-            except AttributeError:
-                # Sometimes mysterious non-string things can turn up in
-                # sys.modules
-                continue
 
         try:
             pkg_resources.working_set.add(dist, replace=True)


### PR DESCRIPTION
This is related to #144, but even more obscure.

For this bug to occur:

1. A package using astropy-helpers (say, WebbPSF) has astropy (or any other package the uses astropy-helpers) as a build-time dependency say, in setup_requires.
2. The top-level package must have an out of date astropy-helpers that automatically upgrades itself, say, from v0.4 to v0.4.8.
3. The secondary package (installed via setup_requires) must also have an out of date astropy-helpers, but of a more recent version generation.  For example, it must have astropy-helpers v1.0 when the latest version in the v1.0.x series is, say, v1.0.1.

When the secondary package tries to upgrade astropy-helpers from v1.0 to v1.0.1 it will fail.  This is because the *previously* upgrade astropy-helpers (v0.4.8) will already be imported and in sys.modules.  In particular the `astropy_helpers.version` module will already be in sys.modules.  astropy-helpers uses this in its setup.py to determine what version string it should use.  So even though the new astropy-helpers has `VERSION = '1.0.1' in its setup.py, it may still end up reporting `version='0.4.8'`, which gets read out of the already imported `astropy_helpers.version` :(

The end result of all this is that astropy-helpers v1.0.1 gets built into a .egg package, but with a filename like `astropy-helpers-0.4.8`.  The easy_install process that is responsible for performing temporary installations of setup_requires packages in turn recognizes this as a failure to fetch/build/install astropy-helpers *v1.0.1*, which it was expecting to find after this process.   Instead it finds something that looks, superficially, like astropy-helpers v0.4.8 and throws up its hands in confusion.

To mitigate this two steps should be taken:

1) Existing imports of `astropy_helpers` and all submodules should be cleaned out of `sys.modules` far earlier in the process of running ah_bootstrap.  The fix in #144 addressed cleaning up old imports of `astropy_helpers`, but too late in the process to affect this specific issue.

2) The `generate_version_py` helper function shouldn't go directly through the import system to get to the `packagename.version` module.  Instead it should open that file and compile it on its own, so that there is no ambiguity as to where it is coming from in any given setup.py run.

I don't think this will affect #144, or in turn astropy/astropy#3541, at least not for now.  But it may be an issue (albeit a rare one) in the future.  And I think it will be easy enough to fix by taking the steps mentioned above.