### PR TITLE
Add `update_submodules` to `setup_helpers.py`

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -50,10 +50,12 @@ except ImportError:
 if sys.version_info[0] < 3:
     _str_types = (str, unicode)
     _text_type = unicode
+    import __builtin__ as _builtins
     PY3 = False
 else:
     _str_types = (str, bytes)
     _text_type = str
+    import builtins as _builtins
     PY3 = True
 
 
@@ -209,6 +211,8 @@ class _Bootstrapper(object):
 
         auto_use = config.pop('auto_use', False)
         bootstrapper = cls(**config)
+
+        _builtins._astropy_helpers_config = config
 
         if auto_use:
             # Run the bootstrapper, otherwise the setup.py is using the old


### PR DESCRIPTION
This adds the same functionality that `ah_bootstrap.py` uses to get `astropy_helpers`, and makes it available for other submodules.

This automatically finds all the submodules by searching through `.gitmodules`, and then, if necessary, inits and updates them.  It respects the `--no-git` and `--offline` flags, and warns when they may be preventing automatic things from happening.

I'm not crazy about how the `--no-git` and `--offline` flags are passed along to setup_helpers, but I couldn't think of a better way.
