### PR TITLE
Fix adaptible test command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ astropy-helpers Changelog
   prevented descriptor classes with a custom metaclass from being documented
   correctly. [#158]
 
+- Fixed interface between ``setup.py test`` command and different versions
+  of the Astropy test runner and/or affiliated package template.  This was
+  originally addressed in astropy-helpers v0.4.4 in order to include support
+  for new ``setup.py test`` options, but the fix was never ported to the
+  v1.0.x series. [#159]
+
 
 1.0.2 (2015-04-02)
 ------------------

--- a/astropy_helpers/test_helpers.py
+++ b/astropy_helpers/test_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import inspect
 import os
 import shutil
 import subprocess
@@ -99,30 +100,23 @@ class AstropyTest(Command, object):
            cmd_pre += pre
            cmd_post += post
 
+        test_args = filter(lambda arg: hasattr(self, arg),
+                           self._get_test_runner_args())
+
+        test_args = ', '.join('{0}={1!r}'.format(arg, getattr(self, arg))
+                              for arg in test_args)
+
         if PY3:
             set_flag = "import builtins; builtins._ASTROPY_TEST_ = True"
         else:
             set_flag = "import __builtin__; __builtin__._ASTROPY_TEST_ = True"
 
-        cmd = ('{cmd_pre}{0}; import {1.package_name}, sys; result = ('
-               '{1.package_name}.test('
-               'package={1.package!r}, '
-               'test_path={1.test_path!r}, '
-               'args={1.args!r}, '
-               'plugins={1.plugins!r}, '
-               'verbose={1.verbose_results!r}, '
-               'pastebin={1.pastebin!r}, '
-               'remote_data={1.remote_data!r}, '
-               'pep8={1.pep8!r}, '
-               'pdb={1.pdb!r}, '
-               'open_files={1.open_files!r}, '
-               'parallel={1.parallel!r}, '
-               'docs_path={1.docs_path!r}, '
-               'skip_docs={1.skip_docs!r}, '
-               'repeat={1.repeat!r})); '
-               '{cmd_post}'
+        cmd = ('{cmd_pre}{0}; import {1.package_name}, sys; result = '
+               '{1.package_name}.test({test_args}); {cmd_post}'
                'sys.exit(result)')
-        return cmd.format(set_flag, self, cmd_pre=cmd_pre, cmd_post=cmd_post)
+
+        return cmd.format(set_flag, self, cmd_pre=cmd_pre,
+                          cmd_post=cmd_post, test_args=test_args)
 
     def _validate_required_deps(self):
         """
@@ -155,7 +149,6 @@ class AstropyTest(Command, object):
         try:
             # Construct this modules testing command
             cmd = self.generate_testing_command()
-
             # Run the tests in a subprocess--this is necessary since
             # new extension modules may have appeared, and this is the
             # easiest way to set up a new environment
@@ -248,3 +241,33 @@ class AstropyTest(Command, object):
                 os.path.abspath('.'), self.testing_path))
 
         return cmd_pre, cmd_post
+
+    def _get_test_runner_args(self):
+        """
+        A hack to determine what arguments are supported by the package's
+        test() function.  In the future there should be a more straightforward
+        API to determine this (really it should be determined by the
+        ``TestRunner`` class for whatever version of Astropy is in use).
+        """
+
+        if PY3:
+            import builtins
+            builtins._ASTROPY_TEST_ = True
+        else:
+            import __builtin__
+            __builtin__._ASTROPY_TEST_ = True
+
+        try:
+            pkg = __import__(self.package_name)
+            if not hasattr(pkg, 'test'):
+                raise ImportError(
+                    'package {0} does not have a {0}.test() function as '
+                    'required by the Astropy test runner'.format(package_name))
+
+            argspec = inspect.getargspec(pkg.test)
+            return argspec.args
+        finally:
+            if PY3:
+                del builtins._ASTROPY_TEST_
+            else:
+                del __builtin__._ASTROPY_TEST_


### PR DESCRIPTION
Fix for the issue I originally mentioned in https://github.com/astropy/astropy-helpers/issues/73#issuecomment-72558556; this is just a matter of porting the change originally made in 1068e261d292814156e6c21f4f1f0a97dcffacc3 to work in the v1.0 release series.

This is still sort of a temporary hack in place of a better solution, but at issue is the interface between the `setup.py test` command, which is provided by astropy-helpers, and the actual capabilities of the astropy test suite in different versions of astropy and/or the package-template being used for affiliated packages.