### PR TITLE
add build_docs command/alias

### DIFF
--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -222,3 +222,7 @@ class AstropyBuildSphinx(SphinxBuildDoc):
             # prevent that from running.  But there's no other apparent way
             # to signal what the return code should be.
             sys.exit(retcode)
+
+
+class AstropyBuildDocs(AstropyBuildSphinx):
+    description = 'alias to the build_sphinx command'

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -278,9 +278,9 @@ def register_commands(package, version, release, srcdir='.'):
         return _module_state['registered_commands']
 
     if _module_state['have_sphinx']:
-        from .commands.build_sphinx import AstropyBuildSphinx
+        from .commands.build_sphinx import AstropyBuildSphinx, AstropyBuildDocs
     else:
-        AstropyBuildSphinx = FakeBuildSphinx
+        AstropyBuildSphinx = AstropyBuildDocs = FakeBuildSphinx
 
     _module_state['registered_commands'] = registered_commands = {
         'test': generate_test_command(package),
@@ -304,7 +304,8 @@ def register_commands(package, version, release, srcdir='.'):
         'install_lib': AstropyInstallLib,
 
         'register': AstropyRegister,
-        'build_sphinx': AstropyBuildSphinx
+        'build_sphinx': AstropyBuildSphinx,
+        'build_docs': AstropyBuildDocs
     }
 
     # Need to override the __name__ here so that the commandline options are


### PR DESCRIPTION
Someone at the Lorentz center python meeting (I think @kbarbary or maybe @cmccully or perhaps @Cadair ?)  mentioned that they found the command ``build_sphinx`` to be confusing.  This basically just adds an alias  to ``build_shinx`` command called ``build_docs`` . 

I have some misgivings about this because it's two commands that do the same thing, but I think ``build_docs`` is much more natural for someone who might not understand what "sphinx" is, so I mildly think it's worth it.

cc @embray @astrofrog 