### PR TITLE
Fix css for Sphinx 1.3

### DIFF
--- a/astropy_helpers/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy_helpers/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
@@ -137,7 +137,6 @@ tt {
   font-family: monospace;
 }
 code {
-  color: rgba(0, 0, 0, 0.75);
   padding: 1px 3px;
 }
 pre {
@@ -160,7 +159,7 @@ img {
 }
 
 /* format inline code with a rounded box */
-tt {
+tt, code {
     margin: 0 2px;
     padding: 0 5px;
     border: 1px solid #ddd;
@@ -168,8 +167,17 @@ tt {
     border-radius: 3px;
 }
 
+code.xref, a code {
+    margin: 0;
+    padding: 0 1px 0 1px;
+    background-color: none;
+    border: none;
+}
+
 /* all code has same box background color, even in headers */
-h1 tt, h2 tt, h3 tt, h4 tt, h5 tt, h6 tt, pre, code, tt {
+h1 tt, h2 tt, h3 tt, h4 tt, h5 tt, h6 tt,
+h1 code, h2 code, h3 code, h4 code, h5 code, h6 code,
+pre, code, tt {
   background-color: #f8f8f8;
 }
 


### PR DESCRIPTION
Fixes #163 so our CSS is compatible with Sphinx 1.3 (where all `<tt>` elements were changed to `<code>`).  This carefully tries not to break things for Sphinx 1.2 in the meantime.