### PR TITLE
Make the font of graphviz diagrams match the HTML

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ astropy-helpers Changelog
   prevented descriptor classes with a custom metaclass from being documented
   correctly. [#158]
 
+- The fonts in graphviz diagrams now match the font of the HTML content.
 
 1.0.2 (2015-04-02)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ astropy-helpers Changelog
   prevented descriptor classes with a custom metaclass from being documented
   correctly. [#158]
 
-- The fonts in graphviz diagrams now match the font of the HTML content.
+- The fonts in graphviz diagrams now match the font of the HTML content. [#169]
 
 1.0.2 (2015-04-02)
 ------------------

--- a/astropy_helpers/sphinx/conf.py
+++ b/astropy_helpers/sphinx/conf.py
@@ -160,6 +160,14 @@ autoclass_content = "both"
 # Render inheritance diagrams in SVG
 graphviz_output_format = "svg"
 
+graphviz_dot_args = [
+    '-Nfontsize=10',
+    '-Nfontname=Helvetica Neue, Helvetica, Arial, sans-serif',
+    '-Efontsize=10',
+    '-Efontname=Helvetica Neue, Helvetica, Arial, sans-serif',
+    '-Gfontsize=10',
+    '-Gfontname=Helvetica Neue, Helvetica, Arial, sans-serif'
+]
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Before this change, the graphviz diagrams use Times New Roman, which doesn't match the font used in the rest of the docs.