### PR TITLE
Use mathjax for math rendering on readthedocs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ astropy-helpers Changelog
 
 - The fonts in graphviz diagrams now match the font of the HTML content. [#169]
 
+- When the documentation is built on readthedocs.org, MathJax will be
+  used for math rendering.  When built elsewhere, the "pngmath"
+  extension is still used for math rendering. [#170]
+
 1.0.2 (2015-04-02)
 ------------------
 

--- a/astropy_helpers/sphinx/conf.py
+++ b/astropy_helpers/sphinx/conf.py
@@ -9,6 +9,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import os
 import warnings
 
 from os import path
@@ -21,6 +22,9 @@ from os import path
 # specific version check, call check_sphinx_version("x.y.z.") from
 # your project's conf.py
 needs_sphinx = '1.2'
+
+
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 
 def check_sphinx_version(expected_version):
@@ -114,7 +118,6 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.pngmath',
     'sphinx.ext.inheritance_diagram',
     'astropy_helpers.sphinx.ext.numpydoc',
     'astropy_helpers.sphinx.ext.astropyautosummary',
@@ -127,6 +130,13 @@ extensions = [
     'astropy_helpers.sphinx.ext.viewcode',  # Use patched version of viewcode
     'astropy_helpers.sphinx.ext.smart_resolver'
     ]
+
+
+if on_rtd:
+    extensions.append('sphinx.ext.mathjax')
+else:
+    extensions.append('sphinx.ext.pngmath')
+
 
 # Above, we use a patched version of viewcode rather than 'sphinx.ext.viewcode'
 # This can be changed to the sphinx version once the following issue is fixed


### PR DESCRIPTION
Using mathjax for rendering math is generally of higher quality (particularly on HiDPI displays) than pngmath (which uses LaTeX at build time to render PNG images).  The reason we don't use mathjax is because then the documentation can't be viewed locally without an internet connection (unless we include around 35MB of extra stuff with our documentation).

However, for readthedocs, we can get away with using MathJax, since viewing the docs on readthedocs doesn't work without an internet connection anyway.  (I don't think they have a feature to download docs for offline viewing, but if they did, obviously this would break that).

I haven't tested this -- I think the only way to test it is to merge it, see how readthedocs likes it for the "latest" build and revert it if there's a problem.  None of that will affect historical or stable builds of the docs, and it's unlikely to even break "latest" since it won't replace content unless the build succeeds.