### PR TITLE
This decorator shouldn't always assume that the docstring exists at a…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ astropy-helpers Changelog
   used for math rendering.  When built elsewhere, the "pngmath"
   extension is still used for math rendering. [#170]
 
+- Fix crash when importing astropy_helpers when running with ``python -OO``
+  [#171]
+
+
 1.0.2 (2015-04-02)
 ------------------
 

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -317,8 +317,9 @@ def extends_doc(extended_func):
     """
 
     def decorator(func):
-        func.__doc__ = '\n\n'.join([extended_func.__doc__.rstrip('\n'),
-                                    func.__doc__.lstrip('\n')])
+        if not (extended_func.__doc__ is None or func.__doc__ is None):
+            func.__doc__ = '\n\n'.join([extended_func.__doc__.rstrip('\n'),
+                                        func.__doc__.lstrip('\n')])
         return func
 
     return decorator


### PR DESCRIPTION
…ll; even if we expect the docstring to exist it may not due to optimized compilation (see astropy/astropy#3923)