### PR TITLE
accept cpp files as valid Cython-produced outputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ astropy-helpers Changelog
 - Fix crash when importing astropy_helpers when running with ``python -OO``
   [#171]
 
+- The ``build`` and ``build_ext`` stages now correctly recognize the presence
+  of C++ files in Cython extensions (previously only vanilla C worked). [#173]
+
 
 1.0.2 (2015-04-02)
 ------------------

--- a/astropy_helpers/commands/build_ext.py
+++ b/astropy_helpers/commands/build_ext.py
@@ -125,9 +125,11 @@ def generate_build_ext_command(packagename, release):
                 if src.endswith('.pyx'):
                     pyxfn = src
                     cfn = src[:-4] + '.c'
+                    cppfn = src[:-4] + '.cpp'
                 elif src.endswith('.c'):
                     pyxfn = src[:-2] + '.pyx'
                     cfn = src
+                    cppfn = src
 
                 if not os.path.isfile(pyxfn):
                     continue
@@ -137,13 +139,15 @@ def generate_build_ext_command(packagename, release):
                 else:
                     if os.path.isfile(cfn):
                         extension.sources[jdx] = cfn
+                    elif os.path.isfile(cppfn):
+                        extension.sources[jdx] = cppfn
                     else:
                         msg = (
-                            'Could not find C file {0} for Cython file {1} '
+                            'Could not find C/C++ file {0}/{3} for Cython file {1} '
                             'when building extension {2}. Cython must be '
                             'installed to build from a git checkout.'.format(
                                 cfn, pyxfn, extension.name))
-                        raise IOError(errno.ENOENT, msg, cfn)
+                        raise IOError(errno.ENOENT, msg, cfn, cppfn)
 
         if orig_run is not None:
             # This should always be the case for a correctly implemented

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -649,7 +649,7 @@ def get_cython_extensions(srcdir, packages, prevextensions=tuple(),
 
     for ext in prevextensions:
         for s in ext.sources:
-            if s.endswith(('.pyx', '.c')):
+            if s.endswith(('.pyx', '.c', '.cpp')):
                 sourcepath = os.path.realpath(os.path.splitext(s)[0])
                 prevsourcepaths.append(sourcepath)
 


### PR DESCRIPTION
This PR is prompted by a strange error @aphearin has been seeing in [halotools](https://github.com/astropy/halotools). The basic problem is that if you use `setup_package.py` to create a Cython extension that uses C++ (as opposed to just C), the extension builds the first time, but every subsequent time it fails with an ``error: [Errno 2] Could not find C file  ...``.

After some investigation I traces the problem to the astropy_helpers `build_ext` command, which checks for ".c" files if it thinks the extension has already been built.  But if the extension is in C++, this  fails incorrectly because the files are ".cpp", not ".c".  So this PR simply adds a check for ".cpp" files as well.

I *think* this is the only place .c is assumes.  There's one other possible place: the helpers command which auto-generates the cython extensions if it finds pyx with c next to it.  I think in this case we don't want to do that because normally you need to explicitly tell cython to use C++ rather than just C.  But it would be easy enough to add if others disagree.

cc @embray @mdboom, as people who've helped write some of the extension-building machinery.  Also, @embray, what's the easiest way to quickly get this to halotools once it's merged?  Would you prefer a quick release, or should we just point it straight to the merge commit on master?
