### PR TITLE
Slight tweak to ensure that the (possible) C++ filename associated wi…

### DIFF
--- a/astropy_helpers/commands/build_ext.py
+++ b/astropy_helpers/commands/build_ext.py
@@ -122,14 +122,11 @@ def generate_build_ext_command(packagename, release):
 
             # Replace .pyx with C-equivalents, unless c files are missing
             for jdx, src in enumerate(extension.sources):
-                if src.endswith('.pyx'):
-                    pyxfn = src
-                    cfn = src[:-4] + '.c'
-                    cppfn = src[:-4] + '.cpp'
-                elif src.endswith('.c'):
-                    pyxfn = src[:-2] + '.pyx'
-                    cfn = src
-                    cppfn = src
+                base, ext = os.path.splitext(src)
+                pyxfn = base + '.pyx'
+                cfn = base + '.c'
+                cppfn = base + '.cpp'
+
 
                 if not os.path.isfile(pyxfn):
                     continue


### PR DESCRIPTION
…th a Cython source is always found.

Followup to #173.  I've tested this against halotools, but probably won't add any other specific tests for now (still making a PR to run the tests though).