### PR TITLE
Fix output of build_sphinx -w option in py 3.x

### DIFF
--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -181,7 +181,7 @@ class AstropyBuildSphinx(SphinxBuildDoc):
 
             stdolines = stdo.splitlines()
 
-            if b'build succeeded.' in stdolines:
+            if 'build succeeded.' in stdolines:
                 retcode = 0
             else:
                 retcode = 1

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -174,7 +174,7 @@ class AstropyBuildSphinx(SphinxBuildDoc):
                                     stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT)
-            stdo, stde = proc.communicate(subproccode.encode('utf-8'))
+            stdo, _ = proc.communicate(subproccode.encode('utf-8'))
             stdo = stdo.decode('utf-8')
 
             print(stdo)

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -175,6 +175,7 @@ class AstropyBuildSphinx(SphinxBuildDoc):
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT)
             stdo, stde = proc.communicate(subproccode.encode('utf-8'))
+            stdo = stdo.decode('utf-8')
 
             print(stdo)
 


### PR DESCRIPTION
In python 3.x, it turns out that using the ``-w`` option causes the output of ``build_sphinx`` to be a single-line string that looks like ``b'...'`` (see gammapy/gammapy#305 for an report about this issue).

The underlying problem is that the ``-w`` path in the ``build_sphinx`` command has to know if the build succeeded, so it saves the stdout using ``subprocess.PIPE``.  It then prints at the end.  This works fine in py 2.x, because the pipes yield strings, but in py 3.x, the pipes yield bytes.  So this PR fixes this by decoding the output as UTF-8.  I *think* that should be safe, but @embray or @mdboom might want to provide input as to whether there's any way to actually check if the output is truly UTF-8.