### PR TITLE
Crash in adjust_compiler when usable compiler isn't found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ astropy-helpers Changelog
 - Fixed issue with the sphinx documentation css where the line numbers for code
   blocks were not aligned with the code. [#179]
 
+- Fixed a crash that could occur on Python 3 when a working C compiler isn't
+  found. [#182]
+
 
 1.0.3 (2015-07-22)
 ------------------

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -212,7 +212,7 @@ def get_compiler_version(compiler):
 
     def try_get_version(flag):
         process = subprocess.Popen(
-            shlex.split(compiler) + [flag],
+            shlex.split(compiler, posix=('win' not in sys.platform)) + [flag],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         stdout, stderr = process.communicate()

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -107,7 +107,7 @@ def adjust_compiler(package):
     """
 
     compiler_mapping = [
-        (b'i686-apple-darwin[0-9]*-llvm-gcc-4.2', 'clang')
+        ('i686-apple-darwin[0-9]*-llvm-gcc-4.2', 'clang')
         ]
 
     if _module_state['adjusted_compiler']:
@@ -220,10 +220,10 @@ def get_compiler_version(compiler):
         if process.returncode != 0:
             return 'unknown'
 
-        output = stdout.strip()
+        output = stdout.strip().decode('latin-1')  # Safest bet
         if not output:
             # Some compilers return their version info on stderr
-            output = stderr.strip()
+            output = stderr.strip().decode('latin-1')
 
         if not output:
             output = 'unknown'

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -360,6 +360,13 @@ def test_adjust_compiler(monkeypatch, tmpdir):
     """.format(python=sys.executable)))
     ugly.chmod(stat.S_IRUSR | stat.S_IEXEC)
 
+    # Scripts with shebang lines don't work implicitly in Windows when passed
+    # to subprocess.Popen, so...
+    if 'win' in sys.platform:
+        good = ' '.join((sys.executable, str(good)))
+        bad = ' '.join((sys.executable, str(bad)))
+        ugly = ' '.join((sys.executable, str(ugly)))
+
     @contextlib.contextmanager
     def test_setup():
         setup_helpers._module_state['adjusted_compiler'] = False

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -382,6 +382,9 @@ def test_adjust_compiler(monkeypatch, tmpdir):
         monkeypatch.setattr(sysconfig, 'get_config_var', lambda v: compiler)
         monkeypatch.setattr(setup_helpers, 'get_distutils_build_option',
                             lambda opt: '')
+        old_cc = os.environ.get('CC')
+        if old_cc is not None:
+            del os.environ['CC']
 
         with test_setup() as log:
             yield log
@@ -389,6 +392,9 @@ def test_adjust_compiler(monkeypatch, tmpdir):
         monkeypatch.undo()
         monkeypatch.undo()
         monkeypatch.undo()
+
+        if old_cc is not None:
+            os.environ['CC'] = old_cc
 
     compiler_setters = (compiler_setter_with_environ,
                         compiler_setter_with_sysconfig)
@@ -412,13 +418,7 @@ def test_adjust_compiler(monkeypatch, tmpdir):
 
     with compiler_setter_with_sysconfig(str(bad)):
         adjust_compiler('astropy')
-        try:
-            assert 'CC' in os.environ and os.environ['CC'] == 'clang'
-        finally:
-            try:
-                del os.environ['CC']
-            except KeyError:
-                pass
+        assert 'CC' in os.environ and os.environ['CC'] == 'clang'
 
     with compiler_setter_with_environ('bogus') as log:
         with pytest.raises(SystemExit):


### PR DESCRIPTION
This showed up via a Stack Overflow question: http://stackoverflow.com/questions/32354982/problems-installing-astropy

If the `get_compiler_version` function fails to find the right way to get the compiler version, it returns the string `'unknown'`.  But the regexp in `adjust_compiler` that checks the compiler version is a bytes regexp.  On Python 2 this is no problem, but on Python 3 it crashes if passed the string `'unknown'`.

This can be replicated by setting the CC environment variable to any program that just exits with a non-zero error code (regardless of arguments).

Note, even if not for this bug the installation would probably still fail if the user lacks a working compiler.