### PR TITLE
Squelch Numpy deprecation warnings when building Cython extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ astropy-helpers Changelog
 - Fixed a crash that could occur on Python 3 when a working C compiler isn't
   found. [#182]
 
+- Quieted warnings about deprecated Numpy API in Cython extensions, when
+  building Cython extensions against Numpy >= 1.7. [#183]
+
 
 1.0.3 (2015-07-22)
 ------------------

--- a/astropy_helpers/commands/build_ext.py
+++ b/astropy_helpers/commands/build_ext.py
@@ -179,4 +179,11 @@ def generate_build_ext_command(packagename, release):
                             'checkout.'.format(base, pyxfn, extension.name))
                         raise IOError(errno.ENOENT, msg, cfn)
 
+                # Current versions of Cython use deprecated Numpy API features
+                # the use of which produces a few warnings when compiling.
+                # These additional flags should squelch those warnings.
+                # TODO: Feel free to remove this if/when a Cython update
+                # removes use of the deprecated Numpy API
+                extension.extra_compile_args.extend([
+                    '-Wp,-w', '-Wno-unused-function'])
     return build_ext


### PR DESCRIPTION
Cython currently makes use of some deprecated (as of Numpy 1.7) interfaces in Numpy's C API, which results in some annoying warnings when building.

We can't disable use of the deprecated API, yet, since Cython depends on it.  But we can squelch those warnings for now, which are not of particular use to us.