### PR TITLE
Add Cython support to the build_ext command late in the setup process

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@ astropy-helpers Changelog
   just ensures that any other imports that occur during build will have this
   flag set. [#191]
 
+- It is now possible to use Cython as a ``setup_requires`` build requirement,
+  and still build Cython extensions even if Cython wasn't available at the
+  beginning of the build processes (that is, is automatically downloaded via
+  setuptools' processing of ``setup_requires``). [#185]
+
 
 1.0.4 (unreleased)
 ------------------

--- a/astropy_helpers/commands/_test_compat.py
+++ b/astropy_helpers/commands/_test_compat.py
@@ -261,6 +261,12 @@ class AstropyTest(Command, object):
 
         return cmd_pre, cmd_post
 
+    # Most of the test runner arguments have the same name as attributes on
+    # this command class, with one exception (for now)
+    _test_runner_arg_attr_map = {
+        'verbose': 'verbose_results'
+    }
+
     def _get_test_runner_args(self):
         """
         A hack to determine what arguments are supported by the package's
@@ -284,7 +290,8 @@ class AstropyTest(Command, object):
                     'required by the Astropy test runner'.format(package_name))
 
             argspec = inspect.getargspec(pkg.test)
-            return argspec.args
+            return [cls._test_runner_arg_attr_map.get(arg, arg)
+                    for arg in argspec.args]
         finally:
             if PY3:
                 del builtins._ASTROPY_TEST_

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -47,17 +47,10 @@ from .commands.build_ext import should_build_with_cython
 _module_state = {
     'adjusted_compiler': False,
     'registered_commands': None,
-    'have_cython': False,
     'have_sphinx': False,
     'package_cache': None,
     'compiler_version_cache': {}
 }
-
-try:
-    import Cython
-    _module_state['have_cython'] = True
-except ImportError:
-    pass
 
 try:
     import sphinx

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 from .. import setup_helpers
 from ..setup_helpers import (get_package_info, register_commands,
                              adjust_compiler)
+from ..commands import build_ext
 from . import *
 
 
@@ -182,7 +183,7 @@ def test_compiler_module(c_extension_test_package):
         assert _eva_.version.compiler != 'unknown'
 
 
-def test_no_cython_buildext(c_extension_test_package):
+def test_no_cython_buildext(c_extension_test_package, monkeypatch):
     """
     Regression test for https://github.com/astropy/astropy-helpers/pull/35
 
@@ -194,8 +195,9 @@ def test_no_cython_buildext(c_extension_test_package):
     test_pkg = c_extension_test_package
 
     # In order for this test to test the correct code path we need to fool
-    # setup_helpers into thinking we don't have Cython installed
-    setup_helpers._module_state['have_cython'] = False
+    # build_ext into thinking we don't have Cython installed
+    monkeypatch.setattr(build_ext, 'should_build_with_cython',
+                        lambda *args: False)
 
     with test_pkg.as_cwd():
         run_setup('setup.py', ['build_ext', '--inplace'])
@@ -210,7 +212,7 @@ def test_no_cython_buildext(c_extension_test_package):
         sys.path.remove(str(test_pkg))
 
 
-def test_missing_cython_c_files(pyx_extension_test_package):
+def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
     """
     Regression test for https://github.com/astropy/astropy-helpers/pull/181
 
@@ -221,8 +223,9 @@ def test_missing_cython_c_files(pyx_extension_test_package):
     test_pkg = pyx_extension_test_package
 
     # In order for this test to test the correct code path we need to fool
-    # setup_helpers into thinking we don't have Cython installed
-    setup_helpers._module_state['have_cython'] = False
+    # build_ext into thinking we don't have Cython installed
+    monkeypatch.setattr(build_ext, 'should_build_with_cython',
+                        lambda *args: False)
 
     with test_pkg.as_cwd():
         with pytest.raises(SystemExit) as exc_info:

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -660,3 +660,179 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
         return parse_version(have_version) >= parse_version(version)
     else:
         return parse_version(have_version) > parse_version(version)
+
+
+# Copy of the classproperty decorator from astropy.utils.decorators
+class classproperty(property):
+    """
+    Similar to `property`, but allows class-level properties.  That is,
+    a property whose getter is like a `classmethod`.
+
+    The wrapped method may explicitly use the `classmethod` decorator (which
+    must become before this decorator), or the `classmethod` may be omitted
+    (it is implicit through use of this decorator).
+
+    .. note::
+
+        classproperty only works for *read-only* properties.  It does not
+        currently allow writeable/deleteable properties, due to subtleties of how
+        Python descriptors work.  In order to implement such properties on a class
+        a metaclass for that class must be implemented.
+
+    Parameters
+    ----------
+    fget : callable
+        The function that computes the value of this property (in particular,
+        the function when this is used as a decorator) a la `property`.
+
+    doc : str, optional
+        The docstring for the property--by default inherited from the getter
+        function.
+
+    lazy : bool, optional
+        If True, caches the value returned by the first call to the getter
+        function, so that it is only called once (used for lazy evaluation
+        of an attribute).  This is analogous to `lazyproperty`.  The ``lazy``
+        argument can also be used when `classproperty` is used as a decorator
+        (see the third example below).  When used in the decorator syntax this
+        *must* be passed in as a keyword argument.
+
+    Examples
+    --------
+
+    ::
+
+        >>> class Foo(object):
+        ...     _bar_internal = 1
+        ...     @classproperty
+        ...     def bar(cls):
+        ...         return cls._bar_internal + 1
+        ...
+        >>> Foo.bar
+        2
+        >>> foo_instance = Foo()
+        >>> foo_instance.bar
+        2
+        >>> foo_instance._bar_internal = 2
+        >>> foo_instance.bar  # Ignores instance attributes
+        2
+
+    As previously noted, a `classproperty` is limited to implementing
+    read-only attributes::
+
+        >>> class Foo(object):
+        ...     _bar_internal = 1
+        ...     @classproperty
+        ...     def bar(cls):
+        ...         return cls._bar_internal
+        ...     @bar.setter
+        ...     def bar(cls, value):
+        ...         cls._bar_internal = value
+        ...
+        Traceback (most recent call last):
+        ...
+        NotImplementedError: classproperty can only be read-only; use a
+        metaclass to implement modifiable class-level properties
+
+    When the ``lazy`` option is used, the getter is only called once::
+
+        >>> class Foo(object):
+        ...     @classproperty(lazy=True)
+        ...     def bar(cls):
+        ...         print("Performing complicated calculation")
+        ...         return 1
+        ...
+        >>> Foo.bar
+        Performing complicated calculation
+        1
+        >>> Foo.bar
+        1
+
+    If a subclass inherits a lazy `classproperty` the property is still
+    re-evaluated for the subclass::
+
+        >>> class FooSub(Foo):
+        ...     pass
+        ...
+        >>> FooSub.bar
+        Performing complicated calculation
+        1
+        >>> FooSub.bar
+        1
+    """
+
+    def __new__(cls, fget=None, doc=None, lazy=False):
+        if fget is None:
+            # Being used as a decorator--return a wrapper that implements
+            # decorator syntax
+            def wrapper(func):
+                return cls(func, lazy=lazy)
+
+            return wrapper
+
+        return super(classproperty, cls).__new__(cls)
+
+    def __init__(self, fget, doc=None, lazy=False):
+        self._lazy = lazy
+        if lazy:
+            self._cache = {}
+        fget = self._wrap_fget(fget)
+
+        super(classproperty, self).__init__(fget=fget, doc=doc)
+
+        # There is a buglet in Python where self.__doc__ doesn't
+        # get set properly on instances of property subclasses if
+        # the doc argument was used rather than taking the docstring
+        # from fget
+        if doc is not None:
+            self.__doc__ = doc
+
+    def __get__(self, obj, objtype=None):
+        if self._lazy and objtype in self._cache:
+            return self._cache[objtype]
+
+        if objtype is not None:
+            # The base property.__get__ will just return self here;
+            # instead we pass objtype through to the original wrapped
+            # function (which takes the class as its sole argument)
+            val = self.fget.__wrapped__(objtype)
+        else:
+            val = super(classproperty, self).__get__(obj, objtype=objtype)
+
+        if self._lazy:
+            if objtype is None:
+                objtype = obj.__class__
+
+            self._cache[objtype] = val
+
+        return val
+
+    def getter(self, fget):
+        return super(classproperty, self).getter(self._wrap_fget(fget))
+
+    def setter(self, fset):
+        raise NotImplementedError(
+            "classproperty can only be read-only; use a metaclass to "
+            "implement modifiable class-level properties")
+
+    def deleter(self, fdel):
+        raise NotImplementedError(
+            "classproperty can only be read-only; use a metaclass to "
+            "implement modifiable class-level properties")
+
+    @staticmethod
+    def _wrap_fget(orig_fget):
+        if isinstance(orig_fget, classmethod):
+            orig_fget = orig_fget.__func__
+
+        # Using stock functools.wraps instead of the fancier version
+        # found later in this module, which is overkill for this purpose
+
+        @functools.wraps(orig_fget)
+        def fget(obj):
+            return orig_fget(obj.__class__)
+
+        # Set the __wrapped__ attribute manually for support on Python 2
+        fget.__wrapped__ = orig_fget
+
+        return fget


### PR DESCRIPTION
This makes it possible to build extension modules using Cython even if Cython was not available at the beginning of the setup.py script.  This means that Cython can be added as a build-time dependency in setup_requires, and still be used later in the build process if it was installed locally via setup_requires.

I plan to use this for astropy/astropy#3229 which I also want to extend to add Cython to the build requirements (only for git checkouts though--never source releases).