### PR TITLE
Test temp root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ astropy-helpers Changelog
 - Fixed a crash in ``ah_bootstrap.py`` when astropy-helpers can't be downloaded
   due to use off the ``--offline`` option, and a local copy is not available.
 
+- Added a new ``temp-root`` option to the ``./setup.py test`` command, which is
+  needed in part to support the upgrade to py.test 2.7 (which itself is needed
+  to support Python 3.5). [#187]
+
 
 1.0.3 (2015-07-22)
 ------------------

--- a/astropy_helpers/test_helpers.py
+++ b/astropy_helpers/test_helpers.py
@@ -57,7 +57,11 @@ class AstropyTest(Command, object):
          "Don't test the documentation .rst files."),
         ('repeat=', None,
          'How many times to repeat each test (can be used to check for '
-         'sporadic failures).')
+         'sporadic failures).'),
+        ('temp-root=', None,
+         'The root directory in which to create the temporary testing files. '
+         'If unspecified the system default is used (e.g. /tmp) as explained '
+         'in the documentation for tempfile.mkstemp.')
     ]
 
     user_options = _fix_user_options(user_options)
@@ -80,6 +84,7 @@ class AstropyTest(Command, object):
         self.docs_path = None
         self.skip_docs = False
         self.repeat = None
+        self.temp_root = None
 
     def finalize_options(self):
         # Normally we would validate the options here, but that's handled in
@@ -193,7 +198,8 @@ class AstropyTest(Command, object):
         build_cmd = self.get_finalized_command('build')
         new_path = os.path.abspath(build_cmd.build_lib)
 
-        self.tmp_dir = tempfile.mkdtemp(prefix=self.package_name + '-test-')
+        self.tmp_dir = tempfile.mkdtemp(prefix=self.package_name + '-test-',
+                                        dir=self.temp_root)
         self.testing_path = os.path.join(self.tmp_dir, os.path.basename(new_path))
         shutil.copytree(new_path, self.testing_path)
         shutil.copy('setup.cfg', self.testing_path)


### PR DESCRIPTION
This is needed as part of the solution for astropy/astropy#4164, which can then be resolved by setting a default temp-root option in the setup.cfg for astropy (or other package).  Tempting to just make this the default, but leaving as is for now.

A separate PR will be needed to implement this for v1.1.0.