### PR TITLE
Ensure common py.test rootdir for test files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ astropy-helpers Changelog
 - Fixed a crash in ``ah_bootstrap.py`` when astropy-helpers can't be downloaded
   due to use off the ``--offline`` option, and a local copy is not available.
 
+- Improved support for py.test >= 2.7--running the ``./setup.py test`` command
+  now copies all doc pages into the temporary test directory as well, so that
+  all test files have a "common root directory". [#189]
+
 
 1.0.3 (2015-07-22)
 ------------------

--- a/astropy_helpers/test_helpers.py
+++ b/astropy_helpers/test_helpers.py
@@ -140,16 +140,17 @@ class AstropyTest(Command, object):
         """
         Run the tests!
         """
-        # Build a testing install of the package
-        self._build_temp_install()
-
-        # Ensure all required packages are installed
-        self._validate_required_deps()
 
         # Ensure there is a doc path
         if self.docs_path is None:
             if os.path.exists('docs'):
                 self.docs_path = os.path.abspath('docs')
+
+        # Build a testing install of the package
+        self._build_temp_install()
+
+        # Ensure all required packages are installed
+        self._validate_required_deps()
 
         # Run everything in a try: finally: so that the tmp dir gets deleted.
         try:
@@ -196,7 +197,13 @@ class AstropyTest(Command, object):
         self.tmp_dir = tempfile.mkdtemp(prefix=self.package_name + '-test-')
         self.testing_path = os.path.join(self.tmp_dir, os.path.basename(new_path))
         shutil.copytree(new_path, self.testing_path)
-        shutil.copy('setup.cfg', self.testing_path)
+
+        new_docs_path = os.path.join(self.tmp_dir,
+                                     os.path.basename(self.docs_path))
+        shutil.copytree(self.docs_path, new_docs_path)
+        self.docs_path = new_docs_path
+
+        shutil.copy('setup.cfg', self.tmp_dir)
 
     def _generate_coverage_commands(self):
         """


### PR DESCRIPTION
This now copies the docs for testing into the temp dir, and ensures that the setup.cfg is in the common root directory for the Python files and the docs.  This ensures that in py.test >= 2.7 the correct common test directory can be found as the 'rootdir'.  Seems to work fine with older versions of py.test as well (down to 2.4).

This replaces #187 as a solution to astropy/astropy#4164