### PR TITLE
Fix astropy import before _ASTROPY_SETUP_ is set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ astropy-helpers Changelog
   continues to work with older versions of Astropy). See the related issue for
   more details. [#184]
 
+- The ``astropy_helpers`` module now sets the global ``_ASTROPY_SETUP_``
+  flag upon import (from within a ``setup.py``) script, so it's not necessary
+  to have this in the ``setup.py`` script explicitly.  If in doubt though,
+  there's no harm in setting it twice.  Putting it in ``astropy_helpers``
+  just ensures that any other imports that occur during build will have this
+  flag set. [#191]
+
 
 1.0.4 (unreleased)
 ------------------

--- a/astropy_helpers/__init__.py
+++ b/astropy_helpers/__init__.py
@@ -37,8 +37,11 @@ except:
 
 # Ensure that all module-level code in astropy or other packages know that
 # we're in setup mode:
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
-builtins._ASTROPY_SETUP_ = True
+if ('__main__' in sys.modules and
+        hasattr(sys.modules['__main__'], '__file__') and
+        sys.modules['__main__'].__file__.startswith('setup.py')):
+    if sys.version_info[0] >= 3:
+        import builtins
+    else:
+        import __builtin__ as builtins
+    builtins._ASTROPY_SETUP_ = True

--- a/astropy_helpers/__init__.py
+++ b/astropy_helpers/__init__.py
@@ -33,3 +33,12 @@ try:
 except:
     # Ignore if this fails for *any* reason*
     pass
+
+
+# Ensure that all module-level code in astropy or other packages know that
+# we're in setup mode:
+if sys.version_info[0] >= 3:
+    import builtins
+else:
+    import __builtin__ as builtins
+builtins._ASTROPY_SETUP_ = True

--- a/astropy_helpers/commands/test.py
+++ b/astropy_helpers/commands/test.py
@@ -12,13 +12,18 @@ that allows users to at least discover the ``./setup.py test`` command and
 learn that they need Astropy to run it.
 """
 
+
+# Previously these except statements caught only ImportErrors, but there are
+# some other obscure exceptional conditions that can occur when importing
+# astropy.tests (at least on older versions) that can cause these imports to
+# fail
 try:
     import astropy
     try:
         from astropy.tests.command import AstropyTest
-    except ImportError:
+    except Exception:
         from ._test_compat import AstropyTest
-except ImportError:
+except Exception:
     # No astropy at all--provide the dummy implementation
     import sys
     from setuptools import Command


### PR DESCRIPTION
This PR implements the fixes needed to astropy-helpers for a regression introduced by #184.  This fix is being tested in astropy/astropy#4179