### PR TITLE
Fix py.test rootdir on OSX

### DIFF
--- a/astropy_helpers/commands/_test_compat.py
+++ b/astropy_helpers/commands/_test_compat.py
@@ -198,8 +198,13 @@ class AstropyTest(Command, object):
         build_cmd = self.get_finalized_command('build')
         new_path = os.path.abspath(build_cmd.build_lib)
 
-        self.tmp_dir = tempfile.mkdtemp(prefix=self.package_name + '-test-',
-                                        dir=self.temp_root)
+        # On OSX the default path for temp files is under /var, but in most
+        # cases on OSX /var is actually a symlink to /private/var; ensure we
+        # dereference that link, because py.test is very sensitive to relative
+        # paths...
+        tmp_dir = tempfile.mkdtemp(prefix=self.package_name + '-test-',
+                                   dir=self.temp_root)
+        self.tmp_dir = os.path.realpath(tmp_dir)
         self.testing_path = os.path.join(self.tmp_dir, os.path.basename(new_path))
         shutil.copytree(new_path, self.testing_path)
 


### PR DESCRIPTION
This is a followup to #189 needed for things to work properly in OSX, where `tempfile.mkdtemp` does *not* return a real path.

This will also need to be backported to the v1.0.x branch.