### PR TITLE
Allow also non-functions/classes to be included in module API summary

### DIFF
--- a/astropy_helpers/extern/automodapi/automodapi.py
+++ b/astropy_helpers/extern/automodapi/automodapi.py
@@ -127,7 +127,7 @@ Functions
 """
 
 automod_templ_other = """
-Other variables
+Global variables
 {otherhds}
 
 .. automodsumm:: {modname}

--- a/astropy_helpers/extern/automodapi/automodapi.py
+++ b/astropy_helpers/extern/automodapi/automodapi.py
@@ -9,6 +9,11 @@ module/package is desired in the documentation, use `automodule`_ instead of
 
 It accepts the following options:
 
+    * ``:include-all-objects:``
+        If present, include not just functions and classes, but all objects.
+        This includes variables, for which a possible docstring after the
+        variable definition will be shown.
+
     * ``:no-inheritance-diagram:``
         If present, the inheritance diagram will not be shown even if
         the module/package has classes.
@@ -121,6 +126,15 @@ Functions
     {clsfuncoptions}
 """
 
+automod_templ_other = """
+Other variables
+{otherhds}
+
+.. automodsumm:: {modname}
+    :no-functions-or-classes:
+    {clsfuncoptions}
+"""
+
 automod_templ_inh = """
 Class Inheritance Diagram
 {clsinhsechds}
@@ -209,6 +223,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
             inhdiag = maindocstr = top_head = True
             hds = '-^'
             allowedpkgnms = []
+            allowothers = False
 
             # look for actual options
             unknownops = []
@@ -230,6 +245,8 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                     inherited_members = True
                 elif opname == 'no-inherited-members':
                     inherited_members = False
+                elif opname == 'include-all-objects':
+                    allowothers = True
                 else:
                     unknownops.append(opname)
 
@@ -256,7 +273,8 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 if warnings:
                     app.warn(msg, location)
 
-            ispkg, hascls, hasfuncs = _mod_info(modnm, toskip, onlylocals=onlylocals)
+            ispkg, hascls, hasfuncs, hasother = _mod_info(
+                modnm, toskip, onlylocals=onlylocals)
 
             # add automodule directive only if no-main-docstr isn't present
             if maindocstr:
@@ -304,6 +322,12 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 newstrs.append(automod_templ_classes.format(
                     modname=modnm,
                     clshds=h2 * 7,
+                    clsfuncoptions=clsfuncoptionstr))
+
+            if allowothers and hasother:
+                newstrs.append(automod_templ_other.format(
+                    modname=modnm,
+                    otherhds=h2 * 15,
                     clsfuncoptions=clsfuncoptionstr))
 
             if inhdiag and hascls:
@@ -359,13 +383,15 @@ def _mod_info(modname, toskip=[], onlylocals=True):
     it has classes or functions.
     """
 
-    hascls = hasfunc = False
+    hascls = hasfunc = hasother = False
 
     for localnm, fqnm, obj in zip(*find_mod_objs(modname, onlylocals=onlylocals)):
         if localnm not in toskip:
             hascls = hascls or inspect.isclass(obj)
             hasfunc = hasfunc or inspect.isroutine(obj)
-            if hascls and hasfunc:
+            hasother = hasother or (not inspect.isclass(obj) and
+                                    not inspect.isroutine(obj))
+            if hascls and hasfunc and hasother:
                 break
 
     # find_mod_objs has already imported modname
@@ -375,7 +401,7 @@ def _mod_info(modname, toskip=[], onlylocals=True):
     ispkg = (hasattr(pkg, '__file__') and isinstance(pkg.__file__, str) and
              os.path.split(pkg.__file__)[1].startswith('__init__.py'))
 
-    return ispkg, hascls, hasfunc
+    return ispkg, hascls, hasfunc, hasother
 
 
 def process_automodapi(app, docname, source):

--- a/astropy_helpers/extern/automodapi/automodsumm.py
+++ b/astropy_helpers/extern/automodapi/automodsumm.py
@@ -107,7 +107,7 @@ class Automodsumm(Autosummary):
     option_spec = dict(Autosummary.option_spec)
     option_spec['functions-only'] = flag
     option_spec['classes-only'] = flag
-    option_spec['no-functions-or-classes'] = flag
+    option_spec['global-variables-only'] = flag
     option_spec['skip'] = _str_list_converter
     option_spec['allowed-package-names'] = _str_list_converter
     option_spec['inherited-members'] = flag
@@ -132,7 +132,7 @@ class Automodsumm(Autosummary):
             # Be sure to respect functions-only and classes-only.
             funconly = 'functions-only' in self.options
             clsonly = 'classes-only' in self.options
-            otheronly = 'no-functions-or-classes' in self.options
+            varonly = 'global-variables-only' in self.options
 
             skipnames = []
             if 'skip' in self.options:
@@ -156,7 +156,7 @@ class Automodsumm(Autosummary):
                 for nm, obj in zip(localnames, objs):
                     if nm not in skipnames and inspect.isclass(obj):
                         cont.append(nm)
-            elif otheronly:
+            elif varonly:
                 cont = []
                 for nm, obj in zip(localnames, objs):
                     if nm not in skipnames and not (inspect.isclass(obj) or
@@ -330,7 +330,7 @@ def automodsumm_to_autosummary_lines(fn, app):
         oplines = ops.split('\n')
         toskip = []
         allowedpkgnms = []
-        funcsonly = clssonly = otheronly = False
+        funcsonly = clssonly = varsonly = False
         for i, ln in reversed(list(enumerate(oplines))):
             if ':functions-only:' in ln:
                 funcsonly = True
@@ -338,8 +338,8 @@ def automodsumm_to_autosummary_lines(fn, app):
             if ':classes-only:' in ln:
                 clssonly = True
                 del oplines[i]
-            if ':no-functions-or-classes:' in ln:
-                otheronly = True
+            if ':global-variables-only:' in ln:
+                varsonly = True
                 del oplines[i]
             if ':skip:' in ln:
                 toskip.extend(_str_list_converter(ln.replace(':skip:', '')))
@@ -370,7 +370,7 @@ def automodsumm_to_autosummary_lines(fn, app):
                 continue
             if clssonly and not inspect.isclass(obj):
                 continue
-            if otheronly and (inspect.isclass(obj) or inspect.isroutine(obj)):
+            if varsonly and (inspect.isclass(obj) or inspect.isroutine(obj)):
                 continue
             newlines.append(allindent + nm)
         newlines.append('')

--- a/astropy_helpers/extern/automodapi/automodsumm.py
+++ b/astropy_helpers/extern/automodapi/automodsumm.py
@@ -107,6 +107,7 @@ class Automodsumm(Autosummary):
     option_spec = dict(Autosummary.option_spec)
     option_spec['functions-only'] = flag
     option_spec['classes-only'] = flag
+    option_spec['no-functions-or-classes'] = flag
     option_spec['skip'] = _str_list_converter
     option_spec['allowed-package-names'] = _str_list_converter
     option_spec['inherited-members'] = flag
@@ -131,6 +132,7 @@ class Automodsumm(Autosummary):
             # Be sure to respect functions-only and classes-only.
             funconly = 'functions-only' in self.options
             clsonly = 'classes-only' in self.options
+            otheronly = 'no-functions-or-classes' in self.options
 
             skipnames = []
             if 'skip' in self.options:
@@ -153,6 +155,12 @@ class Automodsumm(Autosummary):
                 cont = []
                 for nm, obj in zip(localnames, objs):
                     if nm not in skipnames and inspect.isclass(obj):
+                        cont.append(nm)
+            elif otheronly:
+                cont = []
+                for nm, obj in zip(localnames, objs):
+                    if nm not in skipnames and not (inspect.isclass(obj) or
+                                                    inspect.isroutine(obj)):
                         cont.append(nm)
             else:
                 if clsonly and funconly:
@@ -309,7 +317,6 @@ def automodsumm_to_autosummary_lines(fn, app):
     opssecs = spl[3::5]
     indent2s = spl[4::5]
     remainders = spl[5::5]
-
     # only grab automodsumm sections and convert them to autosummary with the
     # entries for all the public objects
     newlines = []
@@ -323,13 +330,16 @@ def automodsumm_to_autosummary_lines(fn, app):
         oplines = ops.split('\n')
         toskip = []
         allowedpkgnms = []
-        funcsonly = clssonly = False
+        funcsonly = clssonly = otheronly = False
         for i, ln in reversed(list(enumerate(oplines))):
             if ':functions-only:' in ln:
                 funcsonly = True
                 del oplines[i]
             if ':classes-only:' in ln:
                 clssonly = True
+                del oplines[i]
+            if ':no-functions-or-classes:' in ln:
+                otheronly = True
                 del oplines[i]
             if ':skip:' in ln:
                 toskip.extend(_str_list_converter(ln.replace(':skip:', '')))
@@ -352,7 +362,6 @@ def automodsumm_to_autosummary_lines(fn, app):
                          '',
                          '.. autosummary::'])
         newlines.extend(oplines)
-
         ols = True if len(allowedpkgnms) == 0 else allowedpkgnms
         for nm, fqn, obj in zip(*find_mod_objs(modnm, onlylocals=ols)):
             if nm in toskip:
@@ -361,8 +370,10 @@ def automodsumm_to_autosummary_lines(fn, app):
                 continue
             if clssonly and not inspect.isclass(obj):
                 continue
+            if otheronly and (inspect.isclass(obj) or inspect.isroutine(obj)):
+                continue
             newlines.append(allindent + nm)
-
+        newlines.append('')
     # add one newline at the end of the autosummary block
     newlines.append('')
 


### PR DESCRIPTION
This is a possible solution to #117, in that it adds an option `:include-all-objects` to `automodapi` that allows one to make a summary of objects that are neither classes nor functions. It works by writing an `automodsumm` section with a new `:no-functions-or-classes` option.

I'm not sure about the approach, or what should be default, and would like to have comments before updating tests and documentation. 
