### PR TITLE
making sure run commands returns 1 if fails

### DIFF
--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -216,6 +216,7 @@ class AstropyBuildSphinx(SphinxBuildDoc):
         else:
             log.warn('Sphinx Documentation subprocess failed with return '
                      'code ' + str(proc.returncode))
+            retcode = proc.returncode
 
         if retcode is not None:
             # this is potentially dangerous in that there might be something


### PR DESCRIPTION
I've noticed in sunpy/sunpy#1591 that the doctest runs where labelled as successful when they were not.
The problem was that the `proc.returncode` was not being used in `sys.exit()` so we were getting things like this:
```bash
Sphinx Documentation subprocess failed with return code 1

The command "if [[ $TEST_MODE == 'doctest' ]];...." exited with 0.
```
The changes proposed seems to make it work... but I'm not sure if that breaks anything else.
