### PR TITLE
Updating .travis to reflect recent miniconda changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,11 @@ before_install:
     - source continuous-integration/travis/install_graphviz_$TRAVIS_OS_NAME.sh
 
 install:
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a
+
     - conda create --yes -n test python=$PYTHON_VERSION
     - source activate test
     - conda install --yes pip "pytest<2.6" sphinx cython numpy

--- a/continuous-integration/travis/install_conda_linux.sh
+++ b/continuous-integration/travis/install_conda_linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
 wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/home/travis/miniconda/bin:$PATH
-conda update --yes conda
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
+

--- a/continuous-integration/travis/install_conda_osx.sh
+++ b/continuous-integration/travis/install_conda_osx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
+# http://conda.pydata.org/docs/travis.html#the-travis-yml-file
 wget http://repo.continuum.io/miniconda/Miniconda-3.7.3-MacOSX-x86_64.sh -O miniconda.sh
-chmod +x miniconda.sh
-./miniconda.sh -b
-export PATH=/Users/travis/miniconda/bin:$PATH
-conda update --yes conda
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
+


### PR DESCRIPTION
Miniconda's default prefix changed recently causing all travis builds failing in core and affiliates. 