### PR TITLE
DistutilsClassError - astropy_helpers.setup_helpers.test must provide user_options

### DIFF
--- a/astropy_helpers/commands/test.py
+++ b/astropy_helpers/commands/test.py
@@ -33,14 +33,18 @@ except Exception:
 
     class _AstropyTestMeta(type):
         """
-        Causes an exception to be raised on accessing user_options so that
-        if ``./setup.py test`` is run with additional command-line options we
-        can provide a useful error message instead of the default that tells
-        users the options are unrecognized.
+        Causes an exception to be raised on accessing attributes of the test
+        command class so that if ``./setup.py test`` is run with additional
+        command-line options we can provide a useful error message instead of
+        the default that tells users the options are unrecognized.
         """
 
-        @property
-        def user_options(cls):
+        def __getattribute__(cls, attr):
+            if attr == 'description':
+                # Allow cls.description to work so that `./setup.py
+                # --help-commands` still works
+                return super(_AstropyTestMeta, cls).__getattribute__(attr)
+
             raise DistutilsArgError(
                 "Test 'test' command requires the astropy package to be "
                 "installed and importable.")


### PR DESCRIPTION
I'm getting this error:
```
Traceback (most recent call last):

  File "setup.py", line 200, in <module>

    **package_info

  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 138, in setup

    ok = dist.parse_command_line()

  File "/Library/Python/2.7/site-packages/setuptools-4.0.1-py2.7.egg/setuptools/dist.py", line 272, in parse_command_line

  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 467, in parse_command_line

    args = self._parse_command_opts(parser, args)

  File "/Library/Python/2.7/site-packages/setuptools-4.0.1-py2.7.egg/setuptools/dist.py", line 556, in _parse_command_opts

  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 540, in _parse_command_opts

    cmd_class

distutils.errors.DistutilsClassError: command class <class 'astropy_helpers.setup_helpers.test'> must provide 'user_options' attribute (a list of tuples)
```
https://travis-ci.org/gammapy/gammapy/jobs/89093897#L109

This is since today, it wasn't there a few days ago, and no change in Gammapy or travis-ci setup.

@astrofrog @embray – Have you seen this before? Is it because the setuptools version is too old? Should astropy-affiliated packages specify setuptools as a required dependency? Which minimal version?