### PR TITLE
Compiler check should be skipped for pure-Python packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ astropy-helpers Changelog
   beginning of the build processes (that is, is automatically downloaded via
   setuptools' processing of ``setup_requires``). [#185]
 
+- Moves the ``adjust_compiler`` check into the ``build_ext`` command itself,
+  so it's only used when actually building extension modules.  This also
+  deprecates the stand-alone ``adjust_compiler`` function. [#76]
+
 
 1.0.6 (unreleased)
 ------------------


### PR DESCRIPTION
As mentioned by @embray in https://github.com/astropy/astropy-helpers/issues/65#issuecomment-50691291 it would be nice if the compiler check were skipped for pure-Python affiliated packages.

The advantage is that then the user can't run into an installation issue because the compiler check can fails (see the issue mentioned above).