### PR TITLE
Get tests working on py.test 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 
     - conda create --yes -n test python=$PYTHON_VERSION
     - source activate test
-    - conda install --yes pip "pytest<2.6" sphinx cython numpy
+    - conda install --yes pip pytest sphinx cython numpy
     - pip install coveralls pytest-cov
     # We cannot install the developer version of setuptools using pip because
     # pip tries to remove the previous version of setuptools before the


### PR DESCRIPTION
Way back in 4d82b0e3f7eda8175aed42a6f399eb1e65fd58ab I disabled running the tests in py.test 2.6 due to some issues in py.test that were causing it to break.  See for example https://bitbucket.org/hpk42/pytest/issue/412/crash-on-bad-stdout#comment-11617176

There are some other bugs I get on py.test 2.6 as well that seem to have more to do with it than with our tests (though it's possible we're exercising some gnarly corner-cases, so I don't blame py.test too much).  This is just a reminder that this should be addressed eventually.