### PR TITLE
Partial workaround for #204

### DIFF
--- a/astropy_helpers/commands/_dummy.py
+++ b/astropy_helpers/commands/_dummy.py
@@ -76,6 +76,6 @@ if sys.version_info[0] < 3:
     """))
 else:
     exec(dedent("""
-        class _DummyCommand(Command, metaclass=_DummyCommandMeta):
+        class _DummyCommand(Command, object, metaclass=_DummyCommandMeta):
             pass
     """))

--- a/astropy_helpers/commands/_dummy.py
+++ b/astropy_helpers/commands/_dummy.py
@@ -1,0 +1,81 @@
+"""
+Provides a base class for a 'dummy' setup.py command that has no functionality
+(probably due to a missing requirement).  This dummy command can raise an
+exception when it is run, explaining to the user what dependencies must be met
+to use this command.
+
+The reason this is at all tricky is that we want the command to be able to
+provide this message even when the user passes arguments to the command.  If we
+don't know ahead of time what arguments the command can take, this is
+difficult, because distutils does not allow unknown arguments to be passed to a
+setup.py command.  This hacks around that restriction to provide a useful error
+message even when a user passes arguments to the dummy implementation of a
+command.
+
+Use this like:
+
+    try:
+        from some_dependency import SetupCommand
+    except ImportError:
+        from ._dummy import _DummyCommand
+
+        class SetupCommand(_DummyCommand):
+            description = \
+                'Implementation of SetupCommand from some_dependency; '
+                'some_dependency must be installed to run this command'
+
+            # This is the message that will be raised when a user tries to
+            # run this command--define it as a class attribute.
+            error_msg = \
+                "The 'setup_command' command requires the some_dependency "
+                "package to be installed and importable."
+"""
+
+import sys
+from setuptools import Command
+from distutils.errors import DistutilsArgError
+from textwrap import dedent
+
+
+class _DummyCommandMeta(type):
+    """
+    Causes an exception to be raised on accessing attributes of a command class
+    so that if ``./setup.py command_name`` is run with additional command-line
+    options we can provide a useful error message instead of the default that
+    tells users the options are unrecognized.
+    """
+
+    def __init__(cls, name, bases, members):
+        if bases == (Command, object):
+            # This is the _DummyCommand base class, presumably
+            return
+
+        if not hasattr(cls, 'description'):
+            raise TypeError(
+                "_DummyCommand subclass must have a 'description' "
+                "attribute.")
+
+        if not hasattr(cls, 'error_msg'):
+            raise TypeError(
+                "_DummyCommand subclass must have an 'error_msg' "
+                "attribute.")
+
+    def __getattribute__(cls, attr):
+        if attr in ('description', 'error_msg'):
+            # Allow cls.description to work so that `./setup.py
+            # --help-commands` still works
+            return super(_DummyCommandMeta, cls).__getattribute__(attr)
+
+        raise DistutilsArgError(cls.error_msg)
+
+
+if sys.version_info[0] < 3:
+    exec(dedent("""
+        class _DummyCommand(Command, object):
+            __metaclass__ = _DummyCommandMeta
+    """))
+else:
+    exec(dedent("""
+        class _DummyCommand(Command, metaclass=_DummyCommandMeta):
+            pass
+    """))

--- a/astropy_helpers/commands/test.py
+++ b/astropy_helpers/commands/test.py
@@ -25,40 +25,11 @@ try:
         from ._test_compat import AstropyTest
 except Exception:
     # No astropy at all--provide the dummy implementation
-    import sys
-    from setuptools import Command
-    from distutils.errors import DistutilsArgError
-    from textwrap import dedent
+    from ._dummy import _DummyCommand
 
-
-    class _AstropyTestMeta(type):
-        """
-        Causes an exception to be raised on accessing attributes of the test
-        command class so that if ``./setup.py test`` is run with additional
-        command-line options we can provide a useful error message instead of
-        the default that tells users the options are unrecognized.
-        """
-
-        def __getattribute__(cls, attr):
-            if attr == 'description':
-                # Allow cls.description to work so that `./setup.py
-                # --help-commands` still works
-                return super(_AstropyTestMeta, cls).__getattribute__(attr)
-
-            raise DistutilsArgError(
-                "Test 'test' command requires the astropy package to be "
-                "installed and importable.")
-
-    if sys.version_info[0] < 3:
-        exec(dedent("""
-            class _AstropyTestBase(Command, object):
-                __metaclass__ = _AstropyTestMeta
-        """))
-    else:
-        exec(dedent("""
-            class _AstropyTestBase(Command, metaclass=_AstropyTestMeta):
-                pass
-        """))
-
-    class AstropyTest(_AstropyTestBase):
+    class AstropyTest(_DummyCommand):
+        command_name = 'test'
         description = 'Run the tests for this package'
+        error_msg = (
+                "The 'test' command requires the astropy package to be "
+                "installed and importable.")


### PR DESCRIPTION
This partially fixes #204 by providing at least the standard `build_ext` options by default, whether or not Cython is installed (incidentally, something I forgot is that setuptools actually does subclass its build_ext option from the Cython build_ext, but it doesn't provide this "late subclassing" of Cython when Cython is provided via setup_requires :/).

This means the problem in #204 is fixed so long as the user does not supply cython-specific options to the build_ext command.  If they do, and Cython is not installed, then functions like [`astropy_helpers.distutils_helpers.get_distutils_option`](https://github.com/astropy/astropy-helpers/blob/v1.1b1/astropy_helpers/distutils_helpers.py#L56) will still fail, because distutils command-line parsing will fail due to the presence of unrecognized options.

A better long-term solution will still be to write our own command-line parsing for `./setup.py` that can allow unrecognized options :/

This workaround will be fine for the vast majority of likely real-world cases though so I'm happy with this for v1.1, with the new command-line parsing something we can address later if needed.