### PR TITLE
Method summary table in HTML docs is empty

### DIFF
--- a/astropy_helpers/sphinx/ext/astropyautosummary.py
+++ b/astropy_helpers/sphinx/ext/astropyautosummary.py
@@ -111,3 +111,12 @@ def setup(app):
     if LooseVersion(sphinx.__version__) < LooseVersion('1.2.0'):
         # this replaces the default autosummary with the astropy one
         app.add_directive('autosummary', AstropyAutosummary)
+    elif LooseVersion(sphinx.__version__) < LooseVersion('1.3.2'):
+        # Patch Autosummary again, but to work around an upstream bug; see
+        # https://github.com/astropy/astropy-helpers/issues/172
+        class PatchedAutosummary(Autosummary):
+            def get_items(self, names):
+                self.genopt['imported-members'] = True
+                return Autosummary.get_items(self, names)
+
+        app.add_directive('autosummary', PatchedAutosummary)


### PR DESCRIPTION
The method summary table in the HTML docs is empty:

Example:  http://astropy.readthedocs.org/en/latest/api/astropy.table.Table.html
![screen shot 2015-07-15 at 11 29 23](https://cloud.githubusercontent.com/assets/852409/8695347/cda9f4b6-2ae4-11e5-913b-6d36cf7a803f.png)

I think this affects all Astropy classes and affiliated packages (at least it does in Gammapy).

@eteq @embray Any idea how to fix that?