### PR TITLE
Add ways to include inherited members into generated class docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,10 @@ astropy-helpers Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added sphinx configuration value ``automodsumm_inherited_members``.
+  If ``True`` this will include members that are inherited from a base
+  class in the generated API docs. Defaults to ``False`` which matches
+  the previous behavior. [#215]
 
 
 1.1.2 (2016-03-9)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,16 +4,16 @@ astropy-helpers Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added sphinx configuration value ``automodsumm_inherited_members``.
+  If ``True`` this will include members that are inherited from a base
+  class in the generated API docs. Defaults to ``False`` which matches
+  the previous behavior. [#215]
 
 
 1.1.3 (unreleased)
 ------------------
 
-- Added sphinx configuration value ``automodsumm_inherited_members``.
-  If ``True`` this will include members that are inherited from a base
-  class in the generated API docs. Defaults to ``False`` which matches
-  the previous behavior. [#215]
+- Nothing changed yet.
 
 
 1.1.2 (2016-03-9)

--- a/astropy_helpers/sphinx/ext/automodapi.py
+++ b/astropy_helpers/sphinx/ext/automodapi.py
@@ -52,12 +52,12 @@ It accepts the following options:
         given, only objects that are actually in a subpackage of the package
         currently being documented are included.
 
-    * ``:inherited-members: True | False``
+    * ``:inherited-members:`` / ``:no-inherited-members:``
         The global sphinx configuration option
         ``automodsumm_inherited_members`` decides if members that a class
         inherits from a base class are included in the generated
-        documentation. The option ``:inherited-members:`` allows to
-        overrride this global setting.
+        documentation. The option ``:inherited-members:`` or ``:no-inherited-members:``
+        allows the user to overrride the global setting.
 
 
 This extension also adds two sphinx configuration options:

--- a/astropy_helpers/sphinx/ext/automodapi.py
+++ b/astropy_helpers/sphinx/ext/automodapi.py
@@ -52,6 +52,14 @@ It accepts the following options:
         given, only objects that are actually in a subpackage of the package
         currently being documented are included.
 
+    * ``:inherited-members: True | False``
+        The global sphinx configuration option
+        ``automodsumm_inherited_members`` decides if members that a class
+        inherits from a base class are included in the generated
+        documentation. The option ``:inherited-members:`` allows to
+        overrride this global setting.
+
+
 This extension also adds two sphinx configuration options:
 
 * ``automodapi_toctreedirnm``
@@ -204,6 +212,7 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
 
             # look for actual options
             unknownops = []
+            inherited_members = None
             for opname, args in _automodapiargsrex.findall(spl[grp * 3 + 2]):
                 if opname == 'skip':
                     toskip.append(args.strip())
@@ -217,6 +226,10 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                     top_head = False
                 elif opname == 'allowed-package-names':
                     allowedpkgnms.append(args.strip())
+                elif opname == 'inherited-members':
+                    inherited_members = True
+                elif opname == 'no-inherited-members':
+                    inherited_members = False
                 else:
                     unknownops.append(opname)
 
@@ -273,6 +286,11 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 clsfuncoptions.append(':skip: ' + ','.join(toskip))
             if allowedpkgnms:
                 clsfuncoptions.append(allowedpkgnms)
+            if hascls: # This makes no sense unless there are classes.
+                if inherited_members is True:
+                    clsfuncoptions.append(':inherited-members:')
+                if inherited_members is False:
+                    clsfuncoptions.append(':no-inherited-members:')
             clsfuncoptionstr = '\n    '.join(clsfuncoptions)
 
             if hasfuncs:

--- a/astropy_helpers/sphinx/ext/automodapi.py
+++ b/astropy_helpers/sphinx/ext/automodapi.py
@@ -75,6 +75,10 @@ This extension also adds two sphinx configuration options:
     actually used by sphinx, so this option is only for figuring out the
     cause of sphinx warnings or other debugging.  Defaults to `False`.
 
+* ``automodsumm_inherited_members``
+    Should be a bool and if ``True`` members that a class inherits from a base
+    class are included in the generated documentation. Defaults to ``False``.
+
 .. _automodule: http://sphinx-doc.org/latest/ext/autodoc.html?highlight=automodule#directive-automodule
 """
 

--- a/astropy_helpers/sphinx/ext/automodsumm.py
+++ b/astropy_helpers/sphinx/ext/automodsumm.py
@@ -405,7 +405,7 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
     from jinja2 import FileSystemLoader, TemplateNotFound
     from jinja2.sandbox import SandboxedEnvironment
 
-    from .utils import find_autosummary_in_lines
+    from .utils import find_autosummary_in_lines_for_automodsumm as find_autosummary_in_lines
 
 
     if info is None:

--- a/astropy_helpers/sphinx/ext/automodsumm.py
+++ b/astropy_helpers/sphinx/ext/automodsumm.py
@@ -22,7 +22,7 @@ This directive requires a single argument that must be a module or
 package.
 
 It also accepts any options supported by the `autosummary`_ directive-
-see `sphinx.ext.autosummary`_ for details. It also accepts two additional
+see `sphinx.ext.autosummary`_ for details. It also accepts some additional
 options:
 
     * ``:classes-only:``
@@ -46,14 +46,19 @@ options:
         given, only objects that are actually in a subpackage of the package
         currently being documented are included.
 
-This extension also adds one sphinx configuration option:
+This extension also adds two sphinx configuration options:
 
 * ``automodsumm_writereprocessed``
-    Should be a bool, and if True, will cause `automodsumm`_ to write files
+    Should be a bool, and if ``True``, will cause `automodsumm`_ to write files
     with any ``automodsumm`` sections replaced with the content Sphinx
     processes after ``automodsumm`` has run.  The output files are not
     actually used by sphinx, so this option is only for figuring out the
-    cause of sphinx warnings or other debugging.  Defaults to `False`.
+    cause of sphinx warnings or other debugging.  Defaults to ``False``.
+
+* ``automodsumm_inherited_members``
+    Should be a bool and if ``True``, will cause `automodsumm`_ to
+    decument class members that are inherited from a base class.
+    Defaults to ``False``.
 
 .. _sphinx.ext.autosummary: http://sphinx-doc.org/latest/ext/autosummary.html
 .. _autosummary: http://sphinx-doc.org/latest/ext/autosummary.html#directive-autosummary
@@ -250,7 +255,8 @@ def process_automodsumm_generation(app):
             generate_automodsumm_docs(lines, sfn, builder=app.builder,
                                       warn=app.warn, info=app.info,
                                       suffix=suffix,
-                                      base_path=app.srcdir)
+                                      base_path=app.srcdir,
+                                      inherited_members=app.config.automodsumm_inherited_members)
 
 #_automodsummrex = re.compile(r'^(\s*)\.\. automodsumm::\s*([A-Za-z0-9_.]+)\s*'
 #                             r'\n\1(\s*)(\S|$)', re.MULTILINE)
@@ -371,7 +377,8 @@ def automodsumm_to_autosummary_lines(fn, app):
 
 def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
                               info=None, base_path=None, builder=None,
-                              template_dir=None):
+                              template_dir=None,
+                              inherited_members=False):
     """
     This function is adapted from
     `sphinx.ext.autosummary.generate.generate_autosummmary_docs` to
@@ -532,11 +539,15 @@ def generate_automodsumm_docs(lines, srcfn, suffix='.rst', warn=None,
                                    get_members_mod(obj, 'exception')
             elif doc.objtype == 'class':
                 api_class_methods = ['__init__', '__call__']
-                ns['members'] = get_members_class(obj, None)
+                ns['members'] = get_members_class(obj, None,
+                                                  include_base=inherited_members)
                 ns['methods'], ns['all_methods'] = \
-                                 get_members_class(obj, 'method', api_class_methods)
+                                 get_members_class(obj, 'method',
+                                                   api_class_methods,
+                                                   include_base=inherited_members)
                 ns['attributes'], ns['all_attributes'] = \
-                                 get_members_class(obj, 'attribute')
+                                 get_members_class(obj, 'attribute',
+                                                   include_base=inherited_members)
                 ns['methods'].sort()
                 ns['attributes'].sort()
 
@@ -604,3 +615,4 @@ def setup(app):
     app.connect('builder-inited', process_automodsumm_generation)
 
     app.add_config_value('automodsumm_writereprocessed', False, True)
+    app.add_config_value('automodsumm_inherited_members', False, 'env')

--- a/astropy_helpers/sphinx/ext/utils.py
+++ b/astropy_helpers/sphinx/ext/utils.py
@@ -1,6 +1,10 @@
 import inspect
 import sys
+import re
+import os
+from warnings import warn
 
+from sphinx.ext.autosummary.generate import find_autosummary_in_docstring
 
 def find_mod_objs(modname, onlylocals=False):
     """ Returns all the public attributes of a module referenced by name.
@@ -63,3 +67,111 @@ def find_mod_objs(modname, onlylocals=False):
         objs = [e for i, e in enumerate(objs) if valids[i]]
 
     return localnames, fqnames, objs
+
+
+def find_autosummary_in_lines(lines, module=None, filename=None):
+    """Find out what items appear in autosummary:: directives in the
+    given lines.
+    Returns a list of (name, toctree, template, inherited_members)
+    where *name* is a name
+    of an object and *toctree* the :toctree: path of the corresponding
+    autosummary directive (relative to the root of the file name),
+    *template* the value of the :template: option, and *inherited_members*
+    is the value of the :inherited-members: option.
+    *toctree*, *template*, and *inherited_members* are ``None`` if the
+    directive does not have the corresponding options set.
+
+    .. note::
+
+       This is a slightly modified version of
+       ``sphinx.ext.autosummary.generate.find_autosummary_in_lines``
+       which recognizes the ``inherited-members`` option.
+    """
+    autosummary_re = re.compile(r'^(\s*)\.\.\s+autosummary::\s*')
+    automodule_re = re.compile(
+        r'^\s*\.\.\s+automodule::\s*([A-Za-z0-9_.]+)\s*$')
+    module_re = re.compile(
+        r'^\s*\.\.\s+(current)?module::\s*([a-zA-Z0-9_.]+)\s*$')
+    autosummary_item_re = re.compile(r'^\s+(~?[_a-zA-Z][a-zA-Z0-9_.]*)\s*.*?')
+    toctree_arg_re = re.compile(r'^\s+:toctree:\s*(.*?)\s*$')
+    template_arg_re = re.compile(r'^\s+:template:\s*(.*?)\s*$')
+    inherited_members_arg_re = re.compile(r'^\s+:inherited-members:\s*$')
+    no_inherited_members_arg_re = re.compile(r'^\s+:no-inherited-members:\s*$')
+
+    documented = []
+
+    toctree = None
+    template = None
+    inherited_members = None
+    current_module = module
+    in_autosummary = False
+    base_indent = ""
+
+    for line in lines:
+        if in_autosummary:
+            m = toctree_arg_re.match(line)
+            if m:
+                toctree = m.group(1)
+                if filename:
+                    toctree = os.path.join(os.path.dirname(filename),
+                                           toctree)
+                continue
+
+            m = template_arg_re.match(line)
+            if m:
+                template = m.group(1).strip()
+                continue
+
+            m = inherited_members_arg_re.match(line)
+            if m:
+                inherited_members = True
+                continue
+
+            m = no_inherited_members_arg_re.match(line)
+            if m:
+                inherited_members = False
+                continue
+
+            if line.strip().startswith(':'):
+                warn(line)
+                continue  # skip options
+
+            m = autosummary_item_re.match(line)
+            if m:
+                name = m.group(1).strip()
+                if name.startswith('~'):
+                    name = name[1:]
+                if current_module and \
+                   not name.startswith(current_module + '.'):
+                    name = "%s.%s" % (current_module, name)
+                documented.append((name, toctree, template,
+                                   inherited_members))
+                continue
+
+            if not line.strip() or line.startswith(base_indent + " "):
+                continue
+
+            in_autosummary = False
+
+        m = autosummary_re.match(line)
+        if m:
+            in_autosummary = True
+            base_indent = m.group(1)
+            toctree = None
+            template = None
+            continue
+
+        m = automodule_re.search(line)
+        if m:
+            current_module = m.group(1).strip()
+            # recurse into the automodule docstring
+            documented.extend(find_autosummary_in_docstring(
+                current_module, filename=filename))
+            continue
+
+        m = module_re.match(line)
+        if m:
+            current_module = m.group(2)
+            continue
+
+    return documented

--- a/astropy_helpers/sphinx/ext/utils.py
+++ b/astropy_helpers/sphinx/ext/utils.py
@@ -69,7 +69,7 @@ def find_mod_objs(modname, onlylocals=False):
     return localnames, fqnames, objs
 
 
-def find_autosummary_in_lines(lines, module=None, filename=None):
+def find_autosummary_in_lines_for_automodsumm(lines, module=None, filename=None):
     """Find out what items appear in autosummary:: directives in the
     given lines.
     Returns a list of (name, toctree, template, inherited_members)


### PR DESCRIPTION
This adds a global sphinx option `automodsumm_inherited_members`.
The default is `False` matching the previous behavior.
However, if set to `True` inherited members of classes will be included
into the generated API documentation.

Note that I added no tests for this behavior. There are no tests for the exiting
behavior either and adding tests for those kind of things is a lot of work.
However, I generated docs and checked by hand that it works as exepcted.

closes #109
[skip ci]