### PR TITLE
CSS fixes for documentation overflows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ astropy-helpers Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The CSS for the sphinx documentation was altered to prevent some text overflow
+  problems. [#217]
 
 
 1.1.1 (2015-12-23)

--- a/astropy_helpers/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy_helpers/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
@@ -234,6 +234,7 @@ div.topbar {
   background-image: -o-linear-gradient(top, #333333, #222222);
   background-image: linear-gradient(top, #333333, #222222);
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#333333', endColorstr='#222222', GradientType=0);
+  overflow: auto;
 }
 
 div.topbar a.brand {

--- a/astropy_helpers/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy_helpers/sphinx/themes/bootstrap-astropy/static/bootstrap-astropy.css
@@ -415,6 +415,10 @@ div.sphinxsidebar {
     border-radius: 3px;
     background-color: #eee;
     border: 1px solid #bbb;
+    word-wrap: break-word;
+    /* overflow-wrap is the canonical name for word-wrap in the CSS3 text draft.
+    We include it here mainly for future-proofing. */
+    overflow-wrap: break-word;
 }
 
 div.sphinxsidebarwrapper {


### PR DESCRIPTION
This makes a couple of changes to the astropy docs addressing two problems:
* Long un-broken words cause the links in the sidebar to overflow onto the body of the text.  The change in ``div.sphinxsidebar`` tells the CSS not to do that.  In pictures, before:
![image](https://cloud.githubusercontent.com/assets/346587/12767533/b12aad16-c9d7-11e5-9560-5aac14f58977.png)
After:
![image](https://cloud.githubusercontent.com/assets/346587/12767536/b49b6594-c9d7-11e5-82fa-1fb217c6d362.png)
* Some weird corruption with the top bar happens for narrow screens as detailed in astropy/astropy#3171 - the ``div.topbar`` change fixes that (I don't really understand now, but I did what the googles told me and it seems to have worked...)

cc @embray @kbarbary @astrofrog

Together these changes should close astropy/astropy#3171 (so @cdeil and @bsipocz might be interested)