### PR TITLE
log.warn is deprecated, so use log.warning instead

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -361,7 +361,7 @@ class _Bootstrapper(object):
         dist = self._directory_import()
 
         if dist is None:
-            log.warn(
+            log.warning(
                 'The requested path {0!r} for importing {1} does not '
                 'exist, or does not contain a copy of the {1} '
                 'package.'.format(self.path, PACKAGE_NAME))
@@ -392,7 +392,7 @@ class _Bootstrapper(object):
             if DEBUG:
                 raise
 
-            log.warn(
+            log.warning(
                 'Failed to import {0} from the specified archive {1!r}: '
                 '{2}'.format(PACKAGE_NAME, self.path, str(e)))
             dist = None
@@ -408,10 +408,10 @@ class _Bootstrapper(object):
 
     def get_index_dist(self):
         if not self.download:
-            log.warn('Downloading {0!r} disabled.'.format(DIST_NAME))
+            log.warning('Downloading {0!r} disabled.'.format(DIST_NAME))
             return None
 
-        log.warn(
+        log.warning(
             "Downloading {0!r}; run setup.py with the --offline option to "
             "force offline installation.".format(DIST_NAME))
 
@@ -420,7 +420,7 @@ class _Bootstrapper(object):
         except Exception as e:
             if DEBUG:
                 raise
-            log.warn(
+            log.warning(
                 'Failed to download and/or install {0!r} from {1!r}:\n'
                 '{2}'.format(DIST_NAME, self.index_url, str(e)))
             dist = None
@@ -589,7 +589,7 @@ class _Bootstrapper(object):
                             '("C").')
             if not stderr.strip().endswith(perl_warning):
                 # Some other unknown error condition occurred
-                log.warn('git submodule command failed '
+                log.warning('git submodule command failed '
                          'unexpectedly:\n{0}'.format(stderr))
                 return False
 
@@ -620,7 +620,7 @@ class _Bootstrapper(object):
             self._update_submodule(m.group('submodule'), m.group('status'))
             return True
         else:
-            log.warn(
+            log.warning(
                 'Unexpected output from `git submodule status`:\n{0}\n'
                 'Will attempt import from {1!r} regardless.'.format(
                     stdout, self.path))
@@ -668,7 +668,7 @@ class _Bootstrapper(object):
         try:
             cfg.readfp(gitmodules_fileobj)
         except Exception as exc:
-            log.warn('Malformatted .gitmodules file: {0}\n'
+            log.warning('Malformatted .gitmodules file: {0}\n'
                      '{1} cannot be assumed to be a git submodule.'.format(
                          exc, self.path))
             return False
@@ -707,7 +707,7 @@ class _Bootstrapper(object):
                 'Please complete or abandon any changes in the submodule so that '
                 'it is in a usable state, then try again.'.format(submodule))
         else:
-            log.warn('Unknown status {0!r} for git submodule {1!r}.  Will '
+            log.warning('Unknown status {0!r} for git submodule {1!r}.  Will '
                      'attempt to use the submodule as-is, but try to ensure '
                      'that the submodule is in a clean state and contains no '
                      'conflicts or errors.\n{2}'.format(status, submodule,
@@ -716,7 +716,7 @@ class _Bootstrapper(object):
 
         err_msg = None
         cmd = ['git', 'submodule'] + cmd + ['--', submodule]
-        log.warn('{0} {1} submodule with: `{2}`'.format(
+        log.warning('{0} {1} submodule with: `{2}`'.format(
             action, submodule, ' '.join(cmd)))
 
         try:
@@ -730,7 +730,7 @@ class _Bootstrapper(object):
                 err_msg = stderr
 
         if err_msg is not None:
-            log.warn('An unexpected error occurred updating the git submodule '
+            log.warning('An unexpected error occurred updating the git submodule '
                      '{0!r}:\n{1}\n{2}'.format(submodule, err_msg,
                                                _err_help_msg))
 

--- a/astropy_helpers/commands/build_ext.py
+++ b/astropy_helpers/commands/build_ext.py
@@ -350,7 +350,7 @@ def generate_build_ext_command(packagename, release):
 
                         cannot be found or executed.
                         """.format(compiler=c_compiler))
-                    log.warn(msg)
+                    log.warning(msg)
                     sys.exit(1)
 
                 for broken, fixed in self._broken_compiler_mapping:
@@ -368,7 +368,7 @@ def generate_build_ext_command(packagename, release):
                             where <command> is the command you ran.
                             """.format(compiler=c_compiler, version=version,
                                        pkg=self.package_name, fixed=fixed))
-                        log.warn(msg)
+                        log.warning(msg)
                         sys.exit(1)
 
                 # If C compiler is set via CC, and isn't broken, we are good to go. We
@@ -411,7 +411,7 @@ def generate_build_ext_command(packagename, release):
 
                             CC=clang python setup.py <command>
                         """.format(compiler=c_compiler))
-                    log.warn(msg)
+                    log.warning(msg)
                     sys.exit(1)
 
                 for broken, fixed in self._broken_compiler_mapping:

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -200,7 +200,7 @@ class AstropyBuildSphinx(SphinxBuildDoc):
                     msg = ('build_sphinx returning a non-zero exit '
                            'code because sphinx issued documentation '
                            'warnings.')
-                log.warn(msg)
+                log.warning(msg)
 
         else:
             proc = subprocess.Popen([sys.executable], stdin=subprocess.PIPE)
@@ -214,10 +214,10 @@ class AstropyBuildSphinx(SphinxBuildDoc):
                     fileurl = 'file://' + pathname2url(index_path)
                     webbrowser.open(fileurl)
                 else:
-                    log.warn('open-docs-in-browser option was given, but '
+                    log.warning('open-docs-in-browser option was given, but '
                              'the builder is not html! Ignoring.')
         else:
-            log.warn('Sphinx Documentation subprocess failed with return '
+            log.warning('Sphinx Documentation subprocess failed with return '
                      'code ' + str(proc.returncode))
             retcode = proc.returncode
 

--- a/astropy_helpers/distutils_helpers.py
+++ b/astropy_helpers/distutils_helpers.py
@@ -190,7 +190,7 @@ def add_command_option(command, name, doc, is_bool=False):
 
     for idx, cmd in enumerate(cmdcls.user_options):
         if cmd[0] == name:
-            log.warn('Overriding existing {0!r} option '
+            log.warning('Overriding existing {0!r} option '
                      '{1!r}'.format(command, name))
             del cmdcls.user_options[idx]
             if name in cmdcls.boolean_options:

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -56,7 +56,7 @@ except ValueError as e:
     # and an occurrence of this bug: http://bugs.python.org/issue18378
     # In this case sphinx is effectively unusable
     if 'unknown locale' in e.args[0]:
-        log.warn(
+        log.warning(
             "Possible misconfiguration of one of the environment variables "
             "LC_ALL, LC_CTYPES, LANG, or LANGUAGE.  For an example of how to "
             "configure your system's language environment on OSX see "
@@ -594,7 +594,7 @@ def pkg_config(packages, default_libraries, executable='pkg-config'):
             "  returncode: {0}".format(e.returncode),
             "  output: {0}".format(e.output)
             ]
-        log.warn('\n'.join(lines))
+        log.warning('\n'.join(lines))
         result['libraries'].extend(default_libraries)
     else:
         if pipe.returncode != 0:
@@ -603,7 +603,7 @@ def pkg_config(packages, default_libraries, executable='pkg-config'):
                     ", ".join(packages)),
                 "This may cause the build to fail below."
                 ]
-            log.warn('\n'.join(lines))
+            log.warning('\n'.join(lines))
             result['libraries'].extend(default_libraries)
         else:
             for token in output.split():

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -189,7 +189,7 @@ def _generate_git_header(packagename, version, githash):
     source = loader.get_source(git_helpers.__name__) or ''
     source_lines = source.splitlines()
     if not source_lines:
-        log.warn('Cannot get source code for astropy_helpers.git_helpers; '
+        log.warning('Cannot get source code for astropy_helpers.git_helpers; '
                  'git support disabled.')
         return ''
 

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -48,7 +48,7 @@ vars(subprocess).setdefault('check_call', _check_call_py24)
 def _install(tarball, install_args=()):
     # extracting the tarball
     tmpdir = tempfile.mkdtemp()
-    log.warn('Extracting in %s', tmpdir)
+    log.warning('Extracting in %s', tmpdir)
     old_wd = os.getcwd()
     try:
         os.chdir(tmpdir)
@@ -59,13 +59,13 @@ def _install(tarball, install_args=()):
         # going in the directory
         subdir = os.path.join(tmpdir, os.listdir(tmpdir)[0])
         os.chdir(subdir)
-        log.warn('Now working in %s', subdir)
+        log.warning('Now working in %s', subdir)
 
         # installing
-        log.warn('Installing Setuptools')
+        log.warning('Installing Setuptools')
         if not _python_cmd('setup.py', 'install', *install_args):
-            log.warn('Something went wrong during the installation.')
-            log.warn('See the error message above.')
+            log.warning('Something went wrong during the installation.')
+            log.warning('See the error message above.')
             # exitcode will be 2
             return 2
     finally:
@@ -76,7 +76,7 @@ def _install(tarball, install_args=()):
 def _build_egg(egg, tarball, to_dir):
     # extracting the tarball
     tmpdir = tempfile.mkdtemp()
-    log.warn('Extracting in %s', tmpdir)
+    log.warning('Extracting in %s', tmpdir)
     old_wd = os.getcwd()
     try:
         os.chdir(tmpdir)
@@ -87,17 +87,17 @@ def _build_egg(egg, tarball, to_dir):
         # going in the directory
         subdir = os.path.join(tmpdir, os.listdir(tmpdir)[0])
         os.chdir(subdir)
-        log.warn('Now working in %s', subdir)
+        log.warning('Now working in %s', subdir)
 
         # building an egg
-        log.warn('Building a Setuptools egg in %s', to_dir)
+        log.warning('Building a Setuptools egg in %s', to_dir)
         _python_cmd('setup.py', '-q', 'bdist_egg', '--dist-dir', to_dir)
 
     finally:
         os.chdir(old_wd)
         shutil.rmtree(tmpdir)
     # returning the result
-    log.warn(egg)
+    log.warning(egg)
     if not os.path.exists(egg):
         raise IOError('Could not build the egg.')
 
@@ -285,7 +285,7 @@ def download_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
     url = download_base + tgz_name
     saveto = os.path.join(to_dir, tgz_name)
     if not os.path.exists(saveto):  # Avoid repeated downloads
-        log.warn("Downloading %s", url)
+        log.warning("Downloading %s", url)
         downloader = downloader_factory()
         downloader(url, saveto)
     return os.path.realpath(saveto)
@@ -345,7 +345,7 @@ def _build_install_args(options):
     install_args = []
     if options.user_install:
         if sys.version_info < (2, 6):
-            log.warn("--user requires Python 2.6 or later")
+            log.warning("--user requires Python 2.6 or later")
             raise SystemExit(1)
         install_args.append('--user')
     return install_args


### PR DESCRIPTION
At least, that's how I understand this message:

    DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead