### PR TITLE
Included licenses in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.rst
 include CHANGES.rst
 include LICENSE.rst
+recursive-include licenses *
 
 include ez_setup.py
 include ah_bootstrap.py


### PR DESCRIPTION
While working on astropy/astropy#4682, I noticed that the licenses directory for the helpers was left out of the ``MANIFEST.in``.  We should include this for consistency, if nothing else.