### PR TITLE
build_sphinx now checks for "build succeeded." on any line.

### DIFF
--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -177,14 +177,13 @@ class AstropyBuildSphinx(SphinxBuildDoc):
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT)
 
+            retcode = 1
             with proc.stdout:
                 for line in iter(proc.stdout.readline, b''):
                     line = line.strip(b'\n')
                     print(line.decode('utf-8'))
-                    if 'build succeeded.' in str(line):
+                    if 'build succeeded.' == str(line):
                         retcode = 0
-                    else:
-                        retcode = 1
 
             # Poll to set proc.retcode
             proc.wait()


### PR DESCRIPTION
This is to work around the effects of sphinx-gallery which prints
information about the gallery build out after the "build succeeded."
message.

The output from a sphinx-gallery build looks like this:


```
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded.
Embedding documentation hyperlinks in examples..
	processing: index.html
	processing: plot_aia_example.html
[done]
The build_sphinx travis build FAILED because sphinx issued documentation warnings (scroll up to see the warnings).
```

This effects astropy/astropy#4734 and sunpy/sunpy#1718.

ping @adrn @eteq 