### PR TITLE
Fixing extension warnings raised by sphinx 1.4

### DIFF
--- a/astropy_helpers/sphinx/conf.py
+++ b/astropy_helpers/sphinx/conf.py
@@ -14,6 +14,9 @@ import warnings
 
 from os import path
 
+import sphinx
+from distutils.version import LooseVersion
+
 
 # -- General configuration ----------------------------------------------------
 
@@ -28,11 +31,8 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 
 def check_sphinx_version(expected_version):
-    import sphinx
-    from distutils import version
-
-    sphinx_version = version.LooseVersion(sphinx.__version__)
-    expected_version = version.LooseVersion(expected_version)
+    sphinx_version = LooseVersion(sphinx.__version__)
+    expected_version = LooseVersion(expected_version)
     if sphinx_version < expected_version:
         raise RuntimeError(
             "At least Sphinx version {0} is required to build this "
@@ -134,6 +134,8 @@ extensions = [
 
 if on_rtd:
     extensions.append('sphinx.ext.mathjax')
+elif LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
+    extensions.append('sphinx.ext.pngmath')
 else:
     extensions.append('sphinx.ext.imgmath')
 

--- a/astropy_helpers/sphinx/conf.py
+++ b/astropy_helpers/sphinx/conf.py
@@ -135,7 +135,7 @@ extensions = [
 if on_rtd:
     extensions.append('sphinx.ext.mathjax')
 else:
-    extensions.append('sphinx.ext.pngmath')
+    extensions.append('sphinx.ext.imgmath')
 
 
 # Above, we use a patched version of viewcode rather than 'sphinx.ext.viewcode'


### PR DESCRIPTION
There are two new warnings coming from the new 1.4 Sphinx. This causes travis failures for the sphinx builds for packages using astropy-helpers. The proposed workaround https://github.com/astropy/ci-helpers/pull/78 is to set the version to a previous release, however on the long term, it's better to deal with them here.

This PR addresses the second warning, as I'm not yet sure how to fix the first one.

```
WARNING: while setting up extension astropy_helpers.sphinx.ext.autodoc_enhancements: directive 'autoattribute' is already registered, it will be overridden
WARNING: sphinx.ext.pngmath has been deprecated. Please use sphinx.ext.imgmath instead.
```

[edit: I've cancelled the appveyor build as it's irrelevant and there was a queue for other packages]