### PR TITLE
Limiting versions of setuptools and sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
 matrix:
     include:
         - os: linux
+          env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION='<20' DEBUG=True
+        - os: linux
           env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=dev
                CONDA_DEPENDENCIES="pytest sphinx cython numpy mercurial mock"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   global:
     - SETUPTOOLS_VERSION=stable
     - SPHINX_VERSION='<1.4'
-    - CONDA_DEPENDENCIES="pytest sphinx cython numpy"
+    - CONDA_DEPENDENCIES="setuptools pytest sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
 
 matrix:
@@ -25,8 +25,8 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION='<20' DEBUG=True
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=dev
-               CONDA_DEPENDENCIES="pytest sphinx cython numpy mercurial mock"
+          env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=dev DEBUG=True
+               CONDA_DEPENDENCIES='pytest sphinx cython numpy'
 
 before_install:
 
@@ -42,7 +42,7 @@ install:
     # pip tries to remove the previous version of setuptools before the
     # installation is complete, which causes issues. Instead, we just install
     # setuptools manually.
-    - if [[ $SETUPTOOLS_VERSION == dev ]]; then hg clone https://bitbucket.org/pypa/setuptools; cd setuptools; python setup.py install; cd ..; fi
+    - if [[ $SETUPTOOLS_VERSION == dev ]]; then git clone http://github.com/pypa/setuptools.git; cd setuptools; python setup.py install; cd ..; fi
 
 before_script:
     # Some of the tests use git commands that require a user to be configured

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - PYTHON_VERSION=3.5
   global:
     - SETUPTOOLS_VERSION=stable
+    - SPHINX_VERSION='<1.4'
     - CONDA_DEPENDENCIES="pytest sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,13 @@ env:
     - PYTHON_VERSION=3.4
     - PYTHON_VERSION=3.5
   global:
-    - SETUPTOOLS_VERSION=stable
+    - SETUPTOOLS_VERSION='<20'
     - SPHINX_VERSION='<1.4'
     - CONDA_DEPENDENCIES="setuptools pytest sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
 
 matrix:
     include:
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION='<20' DEBUG=True
         - os: linux
           env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=dev DEBUG=True
                CONDA_DEPENDENCIES='pytest sphinx cython numpy'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,23 @@ env:
 matrix:
     include:
         - os: linux
+          env: PYTHON_VERSION=2.7 SPHINX_VERSION=1.4
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=20
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=dev DEBUG=True
+               CONDA_DEPENDENCIES='pytest sphinx cython numpy'
+
+    allow_failures:
+        # Remove this once https://github.com/astropy/astropy-helpers/issues/224
+        # is solved and remove the version limitation
+        - os: linux
+          env: PYTHON_VERSION=2.7 SPHINX_VERSION=1.4
+        # Remove these once https://github.com/astropy/astropy-helpers/issues/222
+        # is solved, and set back the default version to 'stable'
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=20
+        - os: linux
           env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=dev DEBUG=True
                CONDA_DEPENDENCIES='pytest sphinx cython numpy'
 


### PR DESCRIPTION
This is to deal temporarily with the latest travis failures that are not affecting functionality.

See details in #222 and #224.

ping @eteq