### PR TITLE
Work around sphinx 1.4 warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
     - PYTHON_VERSION=3.5
   global:
     - SETUPTOOLS_VERSION='<20'
-    - SPHINX_VERSION=stable
     - CONDA_DEPENDENCIES="setuptools pytest sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,12 @@ env:
     - PYTHON_VERSION=3.5
   global:
     - SETUPTOOLS_VERSION='<20'
-    - SPHINX_VERSION='<1.4'
+    - SPHINX_VERSION=stable
     - CONDA_DEPENDENCIES="setuptools pytest sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
 
 matrix:
     include:
-        - os: linux
-          env: PYTHON_VERSION=2.7 SPHINX_VERSION=1.4
         - os: linux
           env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=20
         - os: linux
@@ -31,10 +29,6 @@ matrix:
                CONDA_DEPENDENCIES='pytest sphinx cython numpy'
 
     allow_failures:
-        # Remove this once https://github.com/astropy/astropy-helpers/issues/224
-        # is solved and remove the version limitation
-        - os: linux
-          env: PYTHON_VERSION=2.7 SPHINX_VERSION=1.4
         # Remove these once https://github.com/astropy/astropy-helpers/issues/222
         # is solved, and set back the default version to 'stable'
         - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ astropy-helpers Changelog
   ``--warnings-returncode`` is  given (which is primarily relevant for Travis
   documentation builds).  [#223]
 
+- Fixed ``build_sphinx`` the sphinx extensions to not output a spurious warning
+  for sphinx versions > 1.4. [#229]
+
 
 1.1.2 (2016-03-9)
 -----------------

--- a/astropy_helpers/sphinx/ext/autodoc_enhancements.py
+++ b/astropy_helpers/sphinx/ext/autodoc_enhancements.py
@@ -102,8 +102,10 @@ def setup(app):
     try:
         # this is a really ugly hack to supress a warning that sphinx 1.4
         # generates when overriding an existing directive (which is *desired*
-        # behavior here).  If sphinx implements a better way to supress these
-        # warnings, that should be used (only the `app.add_autodocumenter` call
+        # behavior here).  Once there's a release that includes it, we should
+        # use the fix mentioned in
+        # https://github.com/sphinx-doc/sphinx/issues/2451
+        # and remove this. (only the `app.add_autodocumenter` call
         # call should be left in)
         try:
             # *this* is in a try/finally because we don't want to force six as

--- a/astropy_helpers/sphinx/ext/autodoc_enhancements.py
+++ b/astropy_helpers/sphinx/ext/autodoc_enhancements.py
@@ -6,8 +6,6 @@ import inspect
 import sys
 import types
 
-from io import StringIO
-
 from sphinx.ext.autodoc import AttributeDocumenter, ModuleDocumenter
 from sphinx.util.inspect import isdescriptor
 
@@ -106,7 +104,15 @@ def setup(app):
         # behavior here).  If sphinx implements a better way to supress these
         # warnings, that should be used (only the `app.add_autodocumenter` call
         # call should be left in)
-        app._warning = StringIO()
+        try:
+            # *this* is in a try/finally because we don't want to force six as
+            # a real dependency.  In sphinx 1.4, six is a prerequisite, so
+            # there's no issue. But in older sphinxes this may not be true...
+            # but the inderlying warning is absent anyway so we let it slide.
+            from six import StringIO
+            app._warning = StringIO()
+        except ImportError:
+            pass
         app.add_autodocumenter(AttributeDocumenter)
     finally:
         app._warning = _oldwarn

--- a/astropy_helpers/sphinx/ext/autodoc_enhancements.py
+++ b/astropy_helpers/sphinx/ext/autodoc_enhancements.py
@@ -98,6 +98,7 @@ def setup(app):
     app.add_autodoc_attrgetter(type, type_object_attrgetter)
 
     _oldwarn = app._warning
+    _oldwarncount = app._warncount
     try:
         # this is a really ugly hack to supress a warning that sphinx 1.4
         # generates when overriding an existing directive (which is *desired*
@@ -116,3 +117,4 @@ def setup(app):
         app.add_autodocumenter(AttributeDocumenter)
     finally:
         app._warning = _oldwarn
+        app._warncount = _oldwarncount

--- a/astropy_helpers/sphinx/ext/autodoc_enhancements.py
+++ b/astropy_helpers/sphinx/ext/autodoc_enhancements.py
@@ -6,6 +6,8 @@ import inspect
 import sys
 import types
 
+from io import StringIO
+
 from sphinx.ext.autodoc import AttributeDocumenter, ModuleDocumenter
 from sphinx.util.inspect import isdescriptor
 
@@ -94,5 +96,17 @@ def setup(app):
     # Need to import this too since it re-registers all the documenter types
     # =_=
     import sphinx.ext.autosummary.generate
+
     app.add_autodoc_attrgetter(type, type_object_attrgetter)
-    app.add_autodocumenter(AttributeDocumenter)
+
+    _oldwarn = app._warning
+    try:
+        # this is a really ugly hack to supress a warning that sphinx 1.4
+        # generates when overriding an existing directive (which is *desired*
+        # behavior here).  If sphinx implements a better way to supress these
+        # warnings, that should be used (only the `app.add_autodocumenter` call
+        # call should be left in)
+        app._warning = StringIO()
+        app.add_autodocumenter(AttributeDocumenter)
+    finally:
+        app._warning = _oldwarn


### PR DESCRIPTION
This PR fixes the remaining warning in sphinx 1.4 (see #227). It's a terribly hacky fix, but it's the only way I see to supress the warning. 

Hopefully sphinx-doc/sphinx#2451 will eventually get addressed, and then we can instead suppress the warning in a more reasonable way.

cc @bsipocz 