### PR TITLE
rename _eva_ to apyhtest_eva

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - PYTHON_VERSION=3.4
     - PYTHON_VERSION=3.5
   global:
-    - SETUPTOOLS_VERSION='<20'
+    - SETUPTOOLS_VERSION=stable
     - CONDA_DEPENDENCIES="setuptools pytest sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
 
@@ -28,10 +28,6 @@ matrix:
                CONDA_DEPENDENCIES='pytest sphinx cython numpy'
 
     allow_failures:
-        # Remove these once https://github.com/astropy/astropy-helpers/issues/222
-        # is solved, and set back the default version to 'stable'
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=20
         - os: linux
           env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=dev DEBUG=True
                CONDA_DEPENDENCIES='pytest sphinx cython numpy'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
     - PYTHON_VERSION=3.4
     - PYTHON_VERSION=3.5
   global:
-    - SETUPTOOLS_VERSION=stable
     - CONDA_DEPENDENCIES="setuptools pytest sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
 

--- a/astropy_helpers/sphinx/ext/tests/__init__.py
+++ b/astropy_helpers/sphinx/ext/tests/__init__.py
@@ -14,8 +14,8 @@ def cython_testpackage(tmpdir, request):
     """
 
     test_pkg = tmpdir.mkdir('test_pkg')
-    test_pkg.mkdir('_eva_').ensure('__init__.py')
-    test_pkg.join('_eva_').join('unit02.pyx').write(dedent("""\
+    test_pkg.mkdir('apyhtest_eva').ensure('__init__.py')
+    test_pkg.join('apyhtest_eva').join('unit02.pyx').write(dedent("""\
         def pilot():
             \"\"\"Returns the pilot of Eva Unit-02.\"\"\"
 
@@ -33,7 +33,7 @@ def cython_testpackage(tmpdir, request):
         from setuptools import setup, Extension
         from astropy_helpers.setup_helpers import register_commands
 
-        NAME = '_eva_'
+        NAME = 'apyhtest_eva'
         VERSION = 0.1
         RELEASE = True
 
@@ -43,8 +43,8 @@ def cython_testpackage(tmpdir, request):
             name=NAME,
             version=VERSION,
             cmdclass=cmdclassd,
-            ext_modules=[Extension('_eva_.unit02',
-                                   [join('_eva_', 'unit02.pyx')])]
+            ext_modules=[Extension('apyhtest_eva.unit02',
+                                   [join('apyhtest_eva', 'unit02.pyx')])]
         )
     """.format(os.path.dirname(astropy_helpers.__path__[0]))))
 
@@ -54,10 +54,10 @@ def cython_testpackage(tmpdir, request):
     sp.call([sys.executable, 'setup.py', 'build_ext', '--inplace'])
 
     sys.path.insert(0, str(test_pkg))
-    import _eva_.unit02
+    import apyhtest_eva.unit02
 
     def cleanup(test_pkg=test_pkg):
-        for modname in ['_eva_', '_eva_.unit02']:
+        for modname in ['apyhtest_eva', 'apyhtest_eva.unit02']:
             try:
                 del sys.modules[modname]
             except KeyError:

--- a/astropy_helpers/sphinx/ext/tests/test_automodapi.py
+++ b/astropy_helpers/sphinx/ext/tests/test_automodapi.py
@@ -304,7 +304,7 @@ def test_am_replacer_invalidop():
 am_replacer_cython_str = """
 This comes before
 
-.. automodapi:: _eva_.unit02
+.. automodapi:: apyhtest_eva.unit02
 {options}
 
 This comes after
@@ -313,15 +313,15 @@ This comes after
 am_replacer_cython_expected = """
 This comes before
 
-_eva_.unit02 Module
+apyhtest_eva.unit02 Module
 -------------------
 
-.. automodule:: _eva_.unit02
+.. automodule:: apyhtest_eva.unit02
 
 Functions
 ^^^^^^^^^
 
-.. automodsumm:: _eva_.unit02
+.. automodsumm:: apyhtest_eva.unit02
     :functions-only:
     :toctree: api/
 

--- a/astropy_helpers/sphinx/ext/tests/test_automodapi.py
+++ b/astropy_helpers/sphinx/ext/tests/test_automodapi.py
@@ -314,7 +314,7 @@ am_replacer_cython_expected = """
 This comes before
 
 apyhtest_eva.unit02 Module
--------------------
+--------------------------
 
 .. automodule:: apyhtest_eva.unit02
 

--- a/astropy_helpers/sphinx/ext/tests/test_automodsumm.py
+++ b/astropy_helpers/sphinx/ext/tests/test_automodsumm.py
@@ -85,7 +85,7 @@ def test_ams_to_asmry(tmpdir):
 ams_cython_str = """
 Before
 
-.. automodsumm:: _eva_.unit02
+.. automodsumm:: apyhtest_eva.unit02
     :functions-only:
     :p:
 
@@ -93,7 +93,7 @@ And After
 """
 
 ams_cython_expected = """\
-.. currentmodule:: _eva_.unit02
+.. currentmodule:: apyhtest_eva.unit02
 
 .. autosummary::
     :p:

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -25,7 +25,7 @@ TEST_VERSION_SETUP_PY = """\
 
 from setuptools import setup
 
-NAME = '_eva_'
+NAME = 'apyhtest_eva'
 VERSION = {version!r}
 RELEASE = 'dev' not in VERSION
 
@@ -37,7 +37,7 @@ if not RELEASE:
 
 generate_version_py(NAME, VERSION, RELEASE, False, uses_git=not RELEASE)
 
-setup(name=NAME, version=VERSION, packages=['_eva_'])
+setup(name=NAME, version=VERSION, packages=['apyhtest_eva'])
 """
 
 
@@ -56,7 +56,7 @@ def version_test_package(tmpdir, request):
         test_package = tmpdir.mkdir('test_package')
         test_package.join('setup.py').write(
             TEST_VERSION_SETUP_PY.format(version=version))
-        test_package.mkdir('_eva_').join('__init__.py').write(TEST_VERSION_INIT)
+        test_package.mkdir('apyhtest_eva').join('__init__.py').write(TEST_VERSION_INIT)
         with test_package.as_cwd():
             run_cmd('git', ['init'])
             run_cmd('git', ['add', '--all'])
@@ -68,7 +68,7 @@ def version_test_package(tmpdir, request):
         sys.path.insert(0, '')
 
         def finalize():
-            cleanup_import('_eva_')
+            cleanup_import('apyhtest_eva')
 
         request.addfinalizer(finalize)
 
@@ -97,8 +97,8 @@ def test_update_git_devstr(version_test_package, capsys):
             "\n\n{0}\n\nStderr:\n\n{1}".format(stdout, stderr))
         revcount = int(m.group(1))
 
-        import _eva_
-        assert _eva_.__version__ == version
+        import apyhtest_eva
+        assert apyhtest_eva.__version__ == version
 
         # Make a silly git commit
         with open('.test', 'w'):
@@ -107,14 +107,14 @@ def test_update_git_devstr(version_test_package, capsys):
         run_cmd('git', ['add', '.test'])
         run_cmd('git', ['commit', '-m', 'test'])
 
-        import _eva_.version
-        imp.reload(_eva_.version)
+        import apyhtest_eva.version
+        imp.reload(apyhtest_eva.version)
 
     # Previously this checked packagename.__version__, but in order for that to
     # be updated we also have to re-import _astropy_init which could be tricky.
     # Checking directly that the packagename.version module was updated is
     # sufficient:
-    m = _DEV_VERSION_RE.match(_eva_.version.version)
+    m = _DEV_VERSION_RE.match(apyhtest_eva.version.version)
     assert m
     assert int(m.group(1)) == revcount + 1
 
@@ -126,7 +126,7 @@ def test_update_git_devstr(version_test_package, capsys):
     from astropy_helpers.git_helpers import update_git_devstr
 
     newversion = update_git_devstr(version, path=str(test_pkg))
-    assert newversion == _eva_.version.version
+    assert newversion == apyhtest_eva.version.version
 
 
 def test_version_update_in_other_repos(version_test_package, tmpdir):
@@ -143,8 +143,8 @@ def test_version_update_in_other_repos(version_test_package, tmpdir):
     # Add the path to the test package to sys.path for now
     sys.path.insert(0, str(test_pkg))
     try:
-        import _eva_
-        m = _DEV_VERSION_RE.match(_eva_.__version__)
+        import apyhtest_eva
+        m = _DEV_VERSION_RE.match(apyhtest_eva.__version__)
         assert m
         correct_revcount = int(m.group(1))
 
@@ -154,23 +154,23 @@ def test_version_update_in_other_repos(version_test_package, tmpdir):
             # Create an empty git repo
             run_cmd('git', ['init'])
 
-            import _eva_.version
-            imp.reload(_eva_.version)
-            m = _DEV_VERSION_RE.match(_eva_.version.version)
+            import apyhtest_eva.version
+            imp.reload(apyhtest_eva.version)
+            m = _DEV_VERSION_RE.match(apyhtest_eva.version.version)
             assert m
             assert int(m.group(1)) == correct_revcount
             correct_revcount = int(m.group(1))
 
-            # Add several commits--more than the revcount for the _eva_ package
+            # Add several commits--more than the revcount for the apyhtest_eva package
             for idx in range(correct_revcount + 5):
                 test_filename = '.test' + str(idx)
                 testrepo.ensure(test_filename)
                 run_cmd('git', ['add', test_filename])
                 run_cmd('git', ['commit', '-m', 'A message'])
 
-            import _eva_.version
-            imp.reload(_eva_.version)
-            m = _DEV_VERSION_RE.match(_eva_.version.version)
+            import apyhtest_eva.version
+            imp.reload(apyhtest_eva.version)
+            m = _DEV_VERSION_RE.match(apyhtest_eva.version.version)
             assert m
             assert int(m.group(1)) == correct_revcount
             correct_revcount = int(m.group(1))
@@ -197,14 +197,14 @@ def test_installed_git_version(version_test_package, version, tmpdir, capsys):
         run_setup('setup.py', ['build'])
 
         try:
-            import _eva_
-            githash = _eva_.__githash__
+            import apyhtest_eva
+            githash = apyhtest_eva.__githash__
             assert githash and isinstance(githash, _text_type)
             # Ensure that it does in fact look like a git hash and not some
             # other arbitrary string
             assert re.match(r'[0-9a-f]{40}', githash)
         finally:
-            cleanup_import('_eva_')
+            cleanup_import('apyhtest_eva')
 
         run_setup('setup.py', ['sdist', '--dist-dir=dist', '--formats=gztar'])
 
@@ -218,13 +218,13 @@ def test_installed_git_version(version_test_package, version, tmpdir, capsys):
     tf.extractall(str(build_dir))
 
     with build_dir.as_cwd():
-        pkg_dir = glob.glob('_eva_-*')[0]
+        pkg_dir = glob.glob('apyhtest_eva-*')[0]
         os.chdir(pkg_dir)
         run_setup('setup.py', ['build'])
 
         try:
-            import _eva_
-            loader = pkgutil.get_loader('_eva_')
+            import apyhtest_eva
+            loader = pkgutil.get_loader('apyhtest_eva')
             # Ensure we are importing the 'packagename' that was just unpacked
             # into the build_dir
             if sys.version_info[:2] != (3, 3):
@@ -232,6 +232,6 @@ def test_installed_git_version(version_test_package, version, tmpdir, capsys):
                 # has a bug where get_filename() does not return an absolute
                 # path
                 assert loader.get_filename().startswith(str(build_dir))
-            assert _eva_.__githash__ == githash
+            assert apyhtest_eva.__githash__ == githash
         finally:
-            cleanup_import('_eva_')
+            cleanup_import('apyhtest_eva')

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -16,14 +16,14 @@ def _extension_test_package(tmpdir, request, extension_type='c'):
     """Creates a simple test package with an extension module."""
 
     test_pkg = tmpdir.mkdir('test_pkg')
-    test_pkg.mkdir('_eva_').ensure('__init__.py')
+    test_pkg.mkdir('apyhtest_eva').ensure('__init__.py')
 
     # TODO: It might be later worth making this particular test package into a
     # reusable fixture for other build_ext tests
 
     if extension_type in ('c', 'both'):
         # A minimal C extension for testing
-        test_pkg.join('_eva_', 'unit01.c').write(dedent("""\
+        test_pkg.join('apyhtest_eva', 'unit01.c').write(dedent("""\
             #include <Python.h>
             #ifndef PY3K
             #if PY_MAJOR_VERSION >= 3
@@ -55,7 +55,7 @@ def _extension_test_package(tmpdir, request, extension_type='c'):
 
     if extension_type in ('pyx', 'both'):
         # A minimal Cython extension for testing
-        test_pkg.join('_eva_', 'unit02.pyx').write(dedent("""\
+        test_pkg.join('apyhtest_eva', 'unit02.pyx').write(dedent("""\
             print("Hello cruel angel.")
         """))
 
@@ -67,11 +67,11 @@ def _extension_test_package(tmpdir, request, extension_type='c'):
         extensions = ['unit01.c', 'unit02.pyx']
 
     extensions_list = [
-        "Extension('_eva_.{0}', [join('_eva_', '{1}')])".format(
+        "Extension('apyhtest_eva.{0}', [join('apyhtest_eva', '{1}')])".format(
             os.path.splitext(extension)[0], extension)
         for extension in extensions]
 
-    test_pkg.join('_eva_', 'setup_package.py').write(dedent("""\
+    test_pkg.join('apyhtest_eva', 'setup_package.py').write(dedent("""\
         from setuptools import Extension
         from os.path import join
         def get_extensions():
@@ -85,7 +85,7 @@ def _extension_test_package(tmpdir, request, extension_type='c'):
         from astropy_helpers.setup_helpers import get_package_info
         from astropy_helpers.version_helpers import generate_version_py
 
-        NAME = '_eva_'
+        NAME = 'apyhtest_eva'
         VERSION = '0.1'
         RELEASE = True
 
@@ -107,7 +107,7 @@ def _extension_test_package(tmpdir, request, extension_type='c'):
     sys.path.insert(0, '')
 
     def finalize():
-        cleanup_import('_eva_')
+        cleanup_import('apyhtest_eva')
 
     request.addfinalizer(finalize)
 
@@ -172,15 +172,15 @@ def test_compiler_module(c_extension_test_package):
                    '--record={0}'.format(install_temp.join('record.txt'))])
 
     with install_temp.as_cwd():
-        import _eva_
-        # Make sure we imported the _eva_ package from the correct place
-        dirname = os.path.abspath(os.path.dirname(_eva_.__file__))
-        assert dirname == str(install_temp.join('_eva_'))
+        import apyhtest_eva
+        # Make sure we imported the apyhtest_eva package from the correct place
+        dirname = os.path.abspath(os.path.dirname(apyhtest_eva.__file__))
+        assert dirname == str(install_temp.join('apyhtest_eva'))
 
-        import _eva_._compiler
-        import _eva_.version
-        assert _eva_.version.compiler == _eva_._compiler.compiler
-        assert _eva_.version.compiler != 'unknown'
+        import apyhtest_eva._compiler
+        import apyhtest_eva.version
+        assert apyhtest_eva.version.compiler == apyhtest_eva._compiler.compiler
+        assert apyhtest_eva.version.compiler != 'unknown'
 
 
 def test_no_cython_buildext(c_extension_test_package, monkeypatch):
@@ -205,9 +205,9 @@ def test_no_cython_buildext(c_extension_test_package, monkeypatch):
     sys.path.insert(0, str(test_pkg))
 
     try:
-        import _eva_.unit01
-        dirname = os.path.abspath(os.path.dirname(_eva_.unit01.__file__))
-        assert dirname == str(test_pkg.join('_eva_'))
+        import apyhtest_eva.unit01
+        dirname = os.path.abspath(os.path.dirname(apyhtest_eva.unit01.__file__))
+        assert dirname == str(test_pkg.join('apyhtest_eva'))
     finally:
         sys.path.remove(str(test_pkg))
 
@@ -232,7 +232,7 @@ def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
             run_setup('setup.py', ['build_ext', '--inplace'])
 
     msg = ('Could not find C/C++ file '
-           '{0}.(c/cpp)'.format('_eva_/unit02'.replace('/', os.sep)))
+           '{0}.(c/cpp)'.format('apyhtest_eva/unit02'.replace('/', os.sep)))
 
     assert msg in str(exc_info.value)
 


### PR DESCRIPTION
This is an effort to address the problem in #222 based on @astrofrog's https://github.com/astropy/astropy-helpers/issues/222#issuecomment-210867813 .

I'm actually having some trouble reproducing the issue locally - it *may* be that setuptools 21.x has fixed it?  It's probably good to have this in for insurance anyway, though...  

At any rate, let's see if the tests pass. If so, then I think this closes #222.