### PR TITLE
Adding the suppress_warnings config item ...

### DIFF
--- a/astropy_helpers/sphinx/conf.py
+++ b/astropy_helpers/sphinx/conf.py
@@ -81,6 +81,12 @@ rst_epilog = """
 .. _Astropy: http://astropy.org
 """
 
+# A list of warning types to suppress arbitrary warning messages. We mean to
+# override directives in astropy_helpers.sphinx.ext.autodoc_enhancements,
+# thus need to ignore those warning. This can be removed once the patch gets
+# released in upstream Sphinx (https://github.com/sphinx-doc/sphinx/pull/1843).
+# Suppress the warnings requires Sphinx v1.4.2
+suppress_warnings = ['app.add_directive', ]
 
 # -- Project information ------------------------------------------------------
 


### PR DESCRIPTION
…  to ignore the warning raised by overriding of directives, as we mean to do that. 

This can step into the place of #229 once Sphinx 1.4.2 is out.

@eteq - Do you prefer to merge this now, or should I also include the removal of #229 in here, and leave it open until the new sphinx is out?