### PR TITLE
Add "generated" to list of directories build_sphinx -l removes

### DIFF
--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -67,7 +67,8 @@ class AstropyBuildSphinx(SphinxBuildDoc):
     def finalize_options(self):
         #Clear out previous sphinx builds, if requested
         if self.clean_docs:
-            dirstorm = [os.path.join(self.source_dir, 'api')]
+            dirstorm = [os.path.join(self.source_dir, 'api'),
+                        os.path.join(self.source_dir, 'generated')]
             if self.build_dir is None:
                 dirstorm.append('docs/_build')
             else:


### PR DESCRIPTION
Does just what it says.  This is intended to go with astropy/astropy#4924, and together they will make it so that ``python setup.py build_sphinx -l`` properly cleans out all the build products of the new sphinx gallery extension that's used in astropy.

It also creates a de facto expectation that other sphinx extensions that generate something should put their products in ``generated`` (or ``api``, although that's sort of a special case).