### PR TITLE
AppVeyor and Travis: update Python versions tested to 2.7, 3.3, 3.4, and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ os:
 
 env:
   matrix:
-    - PYTHON_VERSION=2.6
     - PYTHON_VERSION=2.7
     - PYTHON_VERSION=3.3
     - PYTHON_VERSION=3.4
@@ -20,8 +19,10 @@ env:
 
 matrix:
     include:
+
         - os: linux
           env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=20
+
         - os: linux
           env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=dev DEBUG=True
                CONDA_DEPENDENCIES='pytest sphinx cython numpy'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
   global:
       PYTHON: "C:\\conda"
-      MINICONDA_VERSION: "3.5.5"
+      MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
@@ -13,9 +13,10 @@ environment:
       CONDA_DEPENDENCIES: "numpy Cython sphinx pytest"
 
   matrix:
-      - PYTHON_VERSION: "2.6"
       - PYTHON_VERSION: "2.7"
+      - PYTHON_VERSION: "3.3"
       - PYTHON_VERSION: "3.4"
+      - PYTHON_VERSION: "3.5"
 
 platform:
     -x64


### PR DESCRIPTION
cc @bsipocz @eteq