### PR TITLE
Fix encoding error with automodapi_writereprocessed and py2

### DIFF
--- a/astropy_helpers/sphinx/ext/automodapi.py
+++ b/astropy_helpers/sphinx/ext/automodapi.py
@@ -91,6 +91,7 @@ This extension also adds two sphinx configuration options:
 # actually built.
 
 import inspect
+import io
 import os
 import re
 import sys
@@ -330,8 +331,9 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 ustr = newsourcestr.decode(app.config.source_encoding)
 
             if docname is None:
-                with open(os.path.join(app.srcdir, 'unknown.automodapi'), 'a') as f:
-                    f.write('\n**NEW DOC**\n\n')
+                with io.open(os.path.join(app.srcdir, 'unknown.automodapi'),
+                             'a', encoding='utf8') as f:
+                    f.write(u'\n**NEW DOC**\n\n')
                     f.write(ustr)
             else:
                 env = app.builder.env
@@ -340,7 +342,8 @@ def automodapi_replace(sourcestr, app, dotoctree=True, docname=None,
                 filename = docname + os.path.splitext(env.doc2path(docname))[1]
                 filename += '.automodapi'
 
-                with open(os.path.join(app.srcdir, filename), 'w') as f:
+                with io.open(os.path.join(app.srcdir, filename), 'w',
+                             encoding='utf8') as f:
                     f.write(ustr)
 
         return newsourcestr

--- a/astropy_helpers/sphinx/ext/tests/test_automodapi.py
+++ b/astropy_helpers/sphinx/ext/tests/test_automodapi.py
@@ -1,7 +1,5 @@
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-import os
-import sys
 
 import pytest
 
@@ -100,6 +98,31 @@ def test_am_replacer_basic():
     result = automodapi_replace(am_replacer_str.format(options=''), fakeapp)
 
     assert result == am_replacer_basic_expected
+
+
+am_replacer_repr_str = u"""
+This comes before with spéciàl çhars
+
+.. automodapi:: astropy_helpers.sphinx.ext.tests.test_automodapi
+{options}
+
+This comes after
+"""
+
+
+def test_am_replacer_writereprocessed(tmpdir):
+    """
+    Tests the automodapi_writereprocessed option
+    """
+    from ..automodapi import automodapi_replace
+
+    fakeapp = FakeApp()
+    fakeapp.srcdir = str(tmpdir)
+    fakeapp.config.automodapi_writereprocessed = True
+    automodapi_replace(am_replacer_repr_str.format(options=''), fakeapp)
+
+    assert tmpdir.join('unknown.automodapi').isfile()
+
 
 am_replacer_noinh_expected = """
 This comes before


### PR DESCRIPTION
`automodapi_writereprocessed` was not working on Python 2
