### PR TITLE
Deprecate build_sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - PYTHON_VERSION=3.5
   global:
     - CONDA_DEPENDENCIES="setuptools pytest sphinx cython numpy"
-    - PIP_DEPENDENCIES="coveralls pytest-cov"
+    - PIP_DEPENDENCIES="coveralls pytest-cov==2.2"
 
 matrix:
     include:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ astropy-helpers Changelog
 
 - ``astropy_helpers`` now require Sphinx 1.3 or later. [#226]
 
+- ``build_sphinx`` has been deprecated in favor of the ``build_docs`` command.
+  [246]
+
 1.1.2 (2016-03-9)
 -----------------
 

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 import textwrap
+import warnings
 
 from distutils import log
 from distutils.cmd import DistutilsOptionError
@@ -15,15 +16,15 @@ from distutils.cmd import DistutilsOptionError
 import sphinx
 from sphinx.setup_command import BuildDoc as SphinxBuildDoc
 
-from ..utils import minversion
+from ..utils import minversion, AstropyDeprecationWarning
 
 
 PY3 = sys.version_info[0] >= 3
 
 
-class AstropyBuildSphinx(SphinxBuildDoc):
+class AstropyBuildDocs(SphinxBuildDoc):
     """
-    A version of the ``build_sphinx`` command that uses the version of Astropy
+    A version of the ``build_docs`` command that uses the version of Astropy
     that is built by the setup ``build`` command, rather than whatever is
     installed on the system.  To build docs against the installed version, run
     ``make html`` in the ``astropy/docs`` directory.
@@ -112,7 +113,7 @@ class AstropyBuildSphinx(SphinxBuildDoc):
             staticdir = os.path.join(basedir, '_static')
             if os.path.isfile(staticdir):
                 raise DistutilsOptionError(
-                    'Attempted to build_sphinx in a location where' +
+                    'Attempted to build_docs in a location where' +
                     staticdir + 'is a file.  Must be a directory.')
             self.mkpath(staticdir)
 
@@ -198,11 +199,11 @@ class AstropyBuildSphinx(SphinxBuildDoc):
                 if os.environ.get('TRAVIS', None) == 'true':
                     # this means we are in the travis build, so customize
                     # the message appropriately.
-                    msg = ('The build_sphinx travis build FAILED '
+                    msg = ('The build_docs travis build FAILED '
                            'because sphinx issued documentation '
                            'warnings (scroll up to see the warnings).')
                 else:  # standard failure message
-                    msg = ('build_sphinx returning a non-zero exit '
+                    msg = ('build_docs returning a non-zero exit '
                            'code because sphinx issued documentation '
                            'warnings.')
                 log.warn(msg)
@@ -234,5 +235,11 @@ class AstropyBuildSphinx(SphinxBuildDoc):
             sys.exit(retcode)
 
 
-class AstropyBuildDocs(AstropyBuildSphinx):
-    description = 'alias to the build_sphinx command'
+class AstropyBuildSphinx(AstropyBuildDocs):
+    description = 'deprecated alias to the build_docs command'
+
+    def run(self):
+        warnings.warn(
+            'The "build_sphinx" command is now deprecated. Use'
+            '"build_docs" instead.', AstropyDeprecationWarning)
+        super(AstropyBuildSphinx, self).run()

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -235,7 +235,7 @@ class AstropyBuildDocs(SphinxBuildDoc):
             sys.exit(retcode)
 
 
-class AstropyBuildSphinx(AstropyBuildDocs):
+class AstropyBuildSphinx(AstropyBuildDocs): # pragma: no cover
     description = 'deprecated alias to the build_docs command'
 
     def run(self):

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -242,9 +242,9 @@ def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
 
 @pytest.mark.skipif(IS_APPVEYOR, reason='graphviz cannot currently be installed on AppVeyor')
 @pytest.mark.parametrize('mode', ['cli', 'cli-w', 'direct'])
-def test_build_sphinx(tmpdir, mode):
+def test_build_docs(tmpdir, mode):
     """
-    Test for build_sphinx
+    Test for build_docs
     """
 
     import astropy_helpers
@@ -312,9 +312,9 @@ def test_build_sphinx(tmpdir, mode):
         shutil.copytree(ah_path, 'astropy_helpers')
 
         if mode == 'cli':
-            run_setup('setup.py', ['build_sphinx'])
+            run_setup('setup.py', ['build_docs'])
         elif mode == 'cli-w':
-            run_setup('setup.py', ['build_sphinx', '-w'])
+            run_setup('setup.py', ['build_docs', '-w'])
         elif mode == 'direct':  # to check coverage
             with docs_dir.as_cwd():
                 from sphinx import main


### PR DESCRIPTION
This is a fix for #245. This switches the inheritance order of `AstropyBuildDocs` and `AstropyBuildSphinx` and adds a deprecation warning whenever `AstropyBuildSphinx` is run. 