### PR TITLE
Add support for package that lies in a subdirectory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ astropy-helpers Changelog
 2.0 (unreleased)
 ----------------
 
+- Add support for package that lies in a subdirectory. [#249]
 
 1.3.2 (unreleased)
 ------------------

--- a/astropy_helpers/commands/build_ext.py
+++ b/astropy_helpers/commands/build_ext.py
@@ -255,12 +255,14 @@ def generate_build_ext_command(packagename, release):
 
             extensions = self.distribution.ext_modules
             if extensions:
+                build_py = self.get_finalized_command('build_py')
+                package_dir = build_py.get_package_dir(packagename)
                 src_path = os.path.relpath(
                     os.path.join(os.path.dirname(__file__), 'src'))
                 shutil.copy(os.path.join(src_path, 'compiler.c'),
-                            os.path.join(self.package_name, '_compiler.c'))
+                            os.path.join(package_dir, '_compiler.c'))
                 ext = Extension(self.package_name + '._compiler',
-                                [os.path.join(self.package_name, '_compiler.c')])
+                                [os.path.join(package_dir, '_compiler.c')])
                 extensions.insert(0, ext)
 
             super(build_ext, self).finalize_options()
@@ -305,7 +307,8 @@ def generate_build_ext_command(packagename, release):
             except (AttributeError, ImportError):
                 cython_version = 'unknown'
             if self.uses_cython and self.uses_cython != cython_version:
-                package_dir = os.path.relpath(packagename)
+                build_py = self.get_finalized_command('build_py')
+                package_dir = build_py.get_package_dir(packagename)
                 cython_py = os.path.join(package_dir, 'cython_version.py')
                 with open(cython_py, 'w') as f:
                     f.write('# Generated file; do not modify\n')

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -324,7 +324,7 @@ def update_package_files(srcdir, extensions, package_data, packagenames,
 def get_package_info(srcdir='.', exclude=()):
     """
     Collates all of the information for building all subpackages
-    subpackages and returns a dictionary of keyword arguments that can
+    and returns a dictionary of keyword arguments that can
     be passed directly to `distutils.setup`.
 
     The purpose of this function is to allow subpackages to update the
@@ -372,6 +372,10 @@ def get_package_info(srcdir='.', exclude=()):
 
     # Use the find_packages tool to locate all packages and modules
     packages = filter_packages(find_packages(srcdir, exclude=exclude))
+
+    # Update package_dir if the package lies in a subdirectory
+    if srcdir != '.':
+        package_dir[''] = srcdir
 
     # For each of the setup_package.py modules, extract any
     # information that is needed to install them.  The build options

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -218,7 +218,7 @@ def _generate_git_header(packagename, version, githash):
 
 
 def generate_version_py(packagename, version, release=None, debug=None,
-                        uses_git=True):
+                        uses_git=True, srcdir='.'):
     """Regenerate the version.py module if necessary."""
 
     try:
@@ -251,7 +251,7 @@ def generate_version_py(packagename, version, release=None, debug=None,
         # Likewise, keep whatever the current value is, if it exists
         debug = bool(current_debug)
 
-    version_py = os.path.join(packagename, 'version.py')
+    version_py = os.path.join(srcdir, packagename, 'version.py')
 
     if (last_generated_version != version or current_release != release or
             current_debug != debug):


### PR DESCRIPTION
When the root package lies in a subdirectory, like `lib` or `src`, it is already possible to specify a `srcdir` parameter for some functions, but a few things are missing, and a few paths are using `packagename` instead of `package_dir`.
