### PR TITLE
Force the use of Cython's old build_ext command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ astropy-helpers Changelog
 - ``build_sphinx`` has been deprecated in favor of the ``build_docs`` command.
   [#246]
 
+- Force the use of Cython's old ``build_ext`` command. A new ``build_ext``
+  command was added in Cython 0.25, but it does not work with astropy-helpers
+  currently.  [#261]
+
 
 1.2 (2016-06-18)
 ----------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,5 +43,5 @@ install:
 build: false
 
 test_script:
-  - "%CMD_IN_ENV% py.test"
+  - "%CMD_IN_ENV% py.test astropy_helpers"
 

--- a/astropy_helpers/commands/build_ext.py
+++ b/astropy_helpers/commands/build_ext.py
@@ -191,7 +191,10 @@ def generate_build_ext_command(packagename, release):
                 # We need to decide late on whether or not to use Cython's
                 # build_ext (since Cython may not be available earlier in the
                 # setup.py if it was brought in via setup_requires)
-                from Cython.Distutils import build_ext as base_cls
+                try:
+                    from Cython.Distutils.old_build_ext import old_build_ext as base_cls
+                except ImportError:
+                    from Cython.Distutils import build_ext as base_cls
             else:
                 base_cls = SetuptoolsBuildExt
 


### PR DESCRIPTION
A new build_ext command was added in Cython 0.25 (https://github.com/cython/cython/pull/1456) but it breaks Astropy (I could not find why, see https://github.com/astropy/astropy/issues/5437).

Cython 0.25.1 was released to revert this change:
https://github.com/cython/cython/commit/4ecdd3e4e5984011fe93af6c4ccaf6d67a88f6f5

This commit ensures that we always use the old build_ext, whatever the Cython version is. At least until we find why the new build_ext command does not work.
