### PR TITLE
Update CHANGES.rst with version 1.2 release date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 astropy-helpers Changelog
 =========================
 
-1.2 (unreleased)
+1.2 (2016-06-18)
 ----------------
 
 - Added sphinx configuration value ``automodsumm_inherited_members``.


### PR DESCRIPTION
This PR updates CHANGES.rst to mention that version 1.2 was released 2016-06-18

https://pypi.python.org/pypi/astropy-helpers/1.2