### PR TITLE
Adding back sphinx building for Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,10 +36,8 @@ install:
     - git config --global user.name "A U Thor"
     - git config --global user.email "author@example.com"
 
-    # For now we skip the installation of the graphviz package because the
-    # graphviz.org website seems to be unresponsive intermittently, which
-    # causes timeouts in downloads.
-    # - cinst graphviz.portable
+    # Install graphviz
+    - cinst graphviz.portable
 
 # Not a .NET project, we build the package in the install step instead
 build: false

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -187,7 +187,7 @@ class AstropyBuildDocs(SphinxBuildDoc):
             retcode = 1
             with proc.stdout:
                 for line in iter(proc.stdout.readline, b''):
-                    line = line.strip(b'\n')
+                    line = line.strip(b'\r\n')
                     print(line.decode('utf-8'))
                     if 'build succeeded.' == line.decode('utf-8'):
                         retcode = 0

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -1,4 +1,3 @@
-import os
 import contextlib
 import shutil
 import stat
@@ -11,8 +10,6 @@ from setuptools import Distribution
 from ..setup_helpers import get_package_info, register_commands
 from ..commands import build_ext
 from . import *
-
-IS_APPVEYOR = os.environ.get('APPVEYOR', 'False') == 'True'
 
 
 def _extension_test_package(tmpdir, request, extension_type='c'):
@@ -240,7 +237,6 @@ def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
     assert msg in str(exc_info.value)
 
 
-@pytest.mark.skipif(IS_APPVEYOR, reason='graphviz cannot currently be installed on AppVeyor')
 @pytest.mark.parametrize('mode', ['cli', 'cli-w', 'direct', 'deprecated'])
 def test_build_docs(tmpdir, mode):
     """


### PR DESCRIPTION
graphviz.org seems to be back online, so we can remove the workaround added in #241. This will close #240.

Edit: This also fixes #271 