### PR TITLE
Skip registering build_docs if sphinx missing some of its dependencies.

### DIFF
--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -48,6 +48,7 @@ _module_state = {
 
 try:
     import sphinx
+    from .commands.build_sphinx import AstropyBuildSphinx, AstropyBuildDocs
     _module_state['have_sphinx'] = True
 except ValueError as e:
     # This can occur deep in the bowels of Sphinx's imports by way of docutils
@@ -136,9 +137,7 @@ def register_commands(package, version, release, srcdir='.'):
     if _module_state['registered_commands'] is not None:
         return _module_state['registered_commands']
 
-    if _module_state['have_sphinx']:
-        from .commands.build_sphinx import AstropyBuildSphinx, AstropyBuildDocs
-    else:
+    if not _module_state['have_sphinx']:
         AstropyBuildSphinx = AstropyBuildDocs = FakeBuildSphinx
 
     _module_state['registered_commands'] = registered_commands = {

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -48,7 +48,6 @@ _module_state = {
 
 try:
     import sphinx
-    from .commands.build_sphinx import AstropyBuildSphinx, AstropyBuildDocs
     _module_state['have_sphinx'] = True
 except ValueError as e:
     # This can occur deep in the bowels of Sphinx's imports by way of docutils
@@ -134,10 +133,17 @@ def get_debug_option(packagename):
 
 
 def register_commands(package, version, release, srcdir='.'):
+
     if _module_state['registered_commands'] is not None:
         return _module_state['registered_commands']
 
-    if not _module_state['have_sphinx']:
+    if _module_state['have_sphinx']:
+        try:
+            from .commands.build_sphinx import (AstropyBuildSphinx,
+                                                AstropyBuildDocs)
+        except ImportError:
+            AstropyBuildSphinx = AstropyBuildDocs = FakeBuildSphinx
+    else:
         AstropyBuildSphinx = AstropyBuildDocs = FakeBuildSphinx
 
     _module_state['registered_commands'] = registered_commands = {

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -729,7 +729,9 @@ class FakeBuildSphinx(Command):
 
     def initialize_options(self):
         try:
-            raise RuntimeError("Sphinx must be installed for build_sphinx")
+            raise RuntimeError("Sphinx and its dependencies must be installed "
+                               "for build_docs.")
         except:
-            log.error('error: Sphinx must be installed for build_sphinx')
+            log.error('error: Sphinx and its dependencies must be installed '
+                      'for build_docs.')
             sys.exit(1)


### PR DESCRIPTION
This is to fix #228 

Testing this is not trivial, and probably is unneccesary. Locally I've removed ``imagesize`` that reproduced the error reported in #228, and with this fix everything is working again as expected.

One question though: @cdeil would you prefer to receive a warning about the missing dependency/sphinx, or can it stay as it was for the missing sphinx: simple passing in the try/expect.