### PR TITLE
Link to Github repo from PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,16 @@
 astropy-helpers
 ===============
 
+* Stable versions: https://pypi.org/project/astropy-helpers/
+* Development version, issue tracker: https://github.com/astropy/astropy-helpers
+
 This project provides a Python package, ``astropy_helpers``, which includes
 many build, installation, and documentation-related tools used by the Astropy
 project, but packaged separately for use by other projects that wish to
 leverage this work.  The motivation behind this package and details of its
 implementation are in the accepted 
 `Astropy Proposal for Enhancement (APE) 4 <https://github.com/astropy/astropy-APEs/blob/master/APE4.rst>`_.
+
 
 ``astropy_helpers`` includes a special "bootstrap" module called
 ``ah_bootstrap.py`` which is intended to be used by a project's setup.py in

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     author='The Astropy Developers',
     author_email='astropy.team@gmail.com',
     license='BSD',
-    url='http://astropy.org',
+    url=' https://github.com/astropy/astropy-helpers',
     long_description=open('README.rst').read(),
     download_url='{0}/astropy-helpers-{1}.tar.gz'.format(DOWNLOAD_BASE_URL,
                                                          VERSION),


### PR DESCRIPTION
From https://pypi.python.org/pypi/astropy-helpers/1.2 there's currently no link to https://github.com/astropy/astropy-helpers

And the other way around, the README doesn't link to PyPI.

I think it's useful to have that, to be able to quickly go back and forth.

I can make a PR if this is OK with the maintainers.
If yes, OK if I change the URL in setup.py (see https://github.com/astropy/astropy-helpers/blob/master/setup.py#L32) to point to https://github.com/astropy/astropy-helpers, or would you prefer to only have it in the text description?