### PR TITLE
Address pytest deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - PYTHON_VERSION=3.5
   global:
     - CONDA_DEPENDENCIES="setuptools pytest sphinx cython numpy"
-    - PIP_DEPENDENCIES="coveralls pytest-cov==2.2"
+    - PIP_DEPENDENCIES="coveralls pytest-cov"
 
 matrix:
     include:

--- a/astropy_helpers/tests/coveragerc
+++ b/astropy_helpers/tests/coveragerc
@@ -4,7 +4,7 @@ omit =
    astropy_helpers/commands/_test_compat.py
    astropy_helpers/compat/*
    astropy_helpers/*/setup_package.py
-   /tmp/*
+   */test_pkg/*
 
 [report]
 exclude_lines =

--- a/astropy_helpers/tests/coveragerc
+++ b/astropy_helpers/tests/coveragerc
@@ -4,6 +4,7 @@ omit =
    astropy_helpers/commands/_test_compat.py
    astropy_helpers/compat/*
    astropy_helpers/*/setup_package.py
+   /tmp/*
 
 [report]
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 norecursedirs =
     .tox
     astropy_helpers/tests/package_template


### PR DESCRIPTION
Closes #262 

I could only get the other warning go away by removing the version limitation of pytest-cov, hopefully the issue with >=2.3 pytest-cov also went away, but that couldn't be tested with running travis on my fork. Adding milestone 1.3.1 as this is not critical for v1.3.

```
WC1 None pytest_funcarg__cov: declaring fixtures using "pytest_funcarg__" prefix is deprecated and scheduled to be removed in pytest 4.0.  Please remove the prefix and use the @pytest.fixture decorator instead.
```