### PR TITLE
Running cron build for only one version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,11 @@ env:
     - PYTHON_VERSION=2.7
     - PYTHON_VERSION=3.3
     - PYTHON_VERSION=3.4
-    - PYTHON_VERSION=3.5
+    - PYTHON_VERSION=3.5 EVENT_TYPE='push pull_request cron'
   global:
     - CONDA_DEPENDENCIES="setuptools pytest sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
+    - EVENT_TYPE='push pull_request'
 
 matrix:
     include:


### PR DESCRIPTION
I think it should be enough to run only one of the python versions for the cron testing (that currently runs every day), what do you think @astrofrog?