### PR TITLE
Fix button to hide output in documentation code blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ astropy-helpers Changelog
 ----------------
 
 
+1.3.1 (unreleased)
+------------------
+
+- Fixed the missing button to hide output in documentation code
+  blocks. [#287]
+
+
 1.3 (2016-12-16)
 ----------------
 

--- a/astropy_helpers/sphinx/themes/bootstrap-astropy/static/copybutton.js
+++ b/astropy_helpers/sphinx/themes/bootstrap-astropy/static/copybutton.js
@@ -28,6 +28,7 @@ $(document).ready(function() {
             var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
             button.css(button_styles)
             button.attr('title', hide_text);
+            button.data('hidden', 'false');
             jthis.prepend(button);
         }
         // tracebacks (.gt) contain bare text elements that need to be
@@ -38,20 +39,24 @@ $(document).ready(function() {
     });
 
     // define the behavior of the button when it's clicked
-    $('.copybutton').toggle(
-        function() {
-            var button = $(this);
+    $('.copybutton').click(function(e){
+        e.preventDefault();
+        var button = $(this);
+        if (button.data('hidden') === 'false') {
+            // hide the code output
             button.parent().find('.go, .gp, .gt').hide();
             button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
             button.css('text-decoration', 'line-through');
             button.attr('title', show_text);
-        },
-        function() {
-            var button = $(this);
+            button.data('hidden', 'true');
+        } else {
+            // show the code output
             button.parent().find('.go, .gp, .gt').show();
             button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
             button.css('text-decoration', 'none');
             button.attr('title', hide_text);
-        });
+            button.data('hidden', 'false');
+        }
+    });
 });
 

--- a/astropy_helpers/sphinx/themes/bootstrap-astropy/static/copybutton.js
+++ b/astropy_helpers/sphinx/themes/bootstrap-astropy/static/copybutton.js
@@ -3,7 +3,8 @@ $(document).ready(function() {
      * the >>> and ... prompts and the output and thus make the code
      * copyable. */
     var div = $('.highlight-python .highlight,' +
-                '.highlight-python3 .highlight')
+                '.highlight-python3 .highlight,' +
+                '.highlight-default .highlight')
     var pre = div.find('pre');
 
     // get the styles from the current theme


### PR DESCRIPTION
This is currently broken in astropy and all affiliated package docs, unless they have explicitly set `highlight_language` in `docs/conf.py`.  As of `Sphinx 1.4` the highlighting gets set to `default` (which is basically `python3`).

This PR will fix all packages regardless of if they have set `highlight_language`. 