### PR TITLE
Add a path helper for the theme

### DIFF
--- a/astropy_helpers/sphinx/__init__.py
+++ b/astropy_helpers/sphinx/__init__.py
@@ -6,3 +6,11 @@ the Astropy documentation format. Note that some sphinx extensions which are
 bundled as-is (numpydoc and sphinx-automodapi) are included in
 astropy_helpers.extern rather than astropy_helpers.sphinx.ext.
 """
+
+import os
+
+
+def get_html_theme_path():
+    """Return list of HTML theme paths."""
+    cur_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'themes')
+    return [cur_dir]


### PR DESCRIPTION
This is just to make it a little easier to use astropy_helpers just for the sphinx theme.