### PR TITLE
Fix build_sphinx error catcher

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ astropy-helpers Changelog
   convenience. Version shipped with astropy-helpers is v0.5.
   [#278, #303, #309]
 
+- Fix ``build_docs`` error catching, so it doesn't hide Sphinx errors. [#292]
+
+
 1.3.2 (2017-05-29)
 ------------------
 

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -158,7 +158,20 @@ class AstropyBuildDocs(SphinxBuildDoc):
             else:
                 subproccode[i] = repr(val)
         subproccode = ''.join(subproccode)
-
+        
+        optcode = textwrap.dedent("""
+        
+        class Namespace(object): pass
+        self = Namespace()
+        self.pdb = {pdb!r}
+        self.verbosity = {verbosity!r}
+        self.traceback = {traceback!r}
+        
+        """).format(pdb=self.pdb, verbosity=self.verbosity,
+                    traceback=self.traceback)
+        
+        subproccode = optcode + subproccode
+        
         # This is a quick gross hack, but it ensures that the code grabbed from
         # SphinxBuildDoc.run will work in Python 2 if it uses the print
         # function

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -242,7 +242,7 @@ def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
     assert msg in str(exc_info.value)
 
 
-@pytest.mark.parametrize('mode', ['cli', 'cli-w', 'direct', 'deprecated', 'cli-l'])
+@pytest.mark.parametrize('mode', ['cli', 'cli-w', 'direct', 'deprecated', 'cli-l', 'cli-error'])
 def test_build_docs(tmpdir, mode):
     """
     Test for build_docs
@@ -275,7 +275,6 @@ def test_build_docs(tmpdir, mode):
     autosummary.join('module.rst').write('{% extends "autosummary_core/module.rst" %}')
 
     docs_dir = test_pkg.join('docs')
-
     docs_dir.join('conf.py').write(dedent("""\
         import sys
         sys.path.append("../")
@@ -285,6 +284,11 @@ def test_build_docs(tmpdir, mode):
             from astropy_helpers.sphinx.conf import *
         exclude_patterns.append('_templates')
     """))
+    
+    if mode == 'cli-error':
+        docs_dir.join('conf.py').write(dedent("""
+        raise ValueError("TestException")
+        """))
 
     docs_dir.join('index.rst').write(dedent("""\
         .. automodapi:: mypackage


### PR DESCRIPTION
This is the fix suggested by @saimn for issue #288 

It works, but it is still really fragile to upstream changes in Sphinx. I think a more sophisticated solution could be pursued for all of this, but this one does the trick for now.

As for tests: I think we'd need more testing apparatus to really test this one (have to extract output from ``setup.py`` commands, which it looks like ``run_setup`` doesn't currently do). I think a test would be good, but I wanted to put the fix out here first, since this is a really confusing bug.