### PR TITLE
Python intersphinx target has moved to https

### DIFF
--- a/astropy_helpers/sphinx/conf.py
+++ b/astropy_helpers/sphinx/conf.py
@@ -43,7 +43,7 @@ def check_sphinx_version(expected_version):
 
 # Configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/3/',
+    'python': ('https://docs.python.org/3/',
                (None, 'http://data.astropy.org/intersphinx/python3.inv')),
     'pythonloc': ('http://docs.python.org/',
                   path.abspath(path.join(path.dirname(__file__),
@@ -59,7 +59,7 @@ intersphinx_mapping = {
 
 if sys.version_info[0] == 2:
     intersphinx_mapping['python'] = (
-        'http://docs.python.org/2/',
+        'https://docs.python.org/2/',
         (None, 'http://data.astropy.org/intersphinx/python2.inv'))
     intersphinx_mapping['pythonloc'] = (
         'http://docs.python.org/',


### PR DESCRIPTION
This should fix the documentation "warning" I've seen in [`ccdproc`](https://travis-ci.org/astropy/ccdproc/jobs/221047731#L557):

```
loading intersphinx inventory from http://docs.python.org/3/objects.inv...
intersphinx inventory has moved: http://docs.python.org/3/objects.inv -> https://docs.python.org/3/objects.inv
```