### PR TITLE
Backporting fixes for sphinx 1.6+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ env:
 
 matrix:
     include:
+        - os: linux
+          env: PYTHON_VERSION=3.6 SPHINX_VERSION=1.6
 
         - os: linux
           env: PYTHON_VERSION=2.7 SETUPTOOLS_VERSION=20

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ astropy-helpers Changelog
 1.3.2 (unreleased)
 ------------------
 
+- Fix compatibility with Sphinx 1.6. [#304]
 
 1.3.1 (2017-03-18)
 ------------------

--- a/astropy_helpers/sphinx/ext/autodoc_enhancements.py
+++ b/astropy_helpers/sphinx/ext/autodoc_enhancements.py
@@ -5,6 +5,8 @@ Miscellaneous enhancements to help autodoc along.
 import inspect
 import sys
 import types
+import sphinx
+from distutils.version import LooseVersion
 
 from sphinx.ext.autodoc import AttributeDocumenter, ModuleDocumenter
 from sphinx.util.inspect import isdescriptor
@@ -14,6 +16,7 @@ if sys.version_info[0] == 3:
 else:
     class_types = (type, types.ClassType)
 
+SPHINX_LT_15 = (LooseVersion(sphinx.__version__) < LooseVersion('1.5'))
 
 MethodDescriptorType = type(type.__subclasses__)
 
@@ -70,22 +73,23 @@ def type_object_attrgetter(obj, attr, *defargs):
     return getattr(obj, attr, *defargs)
 
 
-# Provided to work around a bug in Sphinx
-# See https://github.com/sphinx-doc/sphinx/pull/1843
-class AttributeDocumenter(AttributeDocumenter):
-    @classmethod
-    def can_document_member(cls, member, membername, isattr, parent):
-        non_attr_types = cls.method_types + class_types + \
-            (MethodDescriptorType,)
-        isdatadesc = isdescriptor(member) and not \
-            isinstance(member, non_attr_types) and not \
-            type(member).__name__ == "instancemethod"
-        # That last condition addresses an obscure case of C-defined
-        # methods using a deprecated type in Python 3, that is not otherwise
-        # exported anywhere by Python
-        return isdatadesc or (not isinstance(parent, ModuleDocumenter) and
-                              not inspect.isroutine(member) and
-                              not isinstance(member, class_types))
+if SPHINX_LT_15:
+    # Provided to work around a bug in Sphinx
+    # See https://github.com/sphinx-doc/sphinx/pull/1843
+    class AttributeDocumenter(AttributeDocumenter):
+        @classmethod
+        def can_document_member(cls, member, membername, isattr, parent):
+            non_attr_types = cls.method_types + class_types + \
+                (MethodDescriptorType,)
+            isdatadesc = isdescriptor(member) and not \
+                isinstance(member, non_attr_types) and not \
+                type(member).__name__ == "instancemethod"
+            # That last condition addresses an obscure case of C-defined
+            # methods using a deprecated type in Python 3, that is not
+            # otherwise exported anywhere by Python
+            return isdatadesc or (not isinstance(parent, ModuleDocumenter) and
+                                  not inspect.isroutine(member) and
+                                  not isinstance(member, class_types))
 
 
 def setup(app):

--- a/astropy_helpers/sphinx/ext/automodsumm.py
+++ b/astropy_helpers/sphinx/ext/automodsumm.py
@@ -308,7 +308,12 @@ def automodsumm_to_autosummary_lines(fn, app):
     fullfn = os.path.join(app.builder.env.srcdir, fn)
 
     with open(fullfn) as fr:
-        if 'astropy_helpers.sphinx.ext.automodapi' in app._extensions:
+        try:
+            extensions = app.extensions
+        except AttributeError:   # Sphinx <1.6
+            extensions = app._extensions
+
+        if 'astropy_helpers.sphinx.ext.automodapi' in extensions:
             from astropy_helpers.sphinx.ext.automodapi import automodapi_replace
             # Must do the automodapi on the source to get the automodsumm
             # that might be in there

--- a/astropy_helpers/sphinx/ext/tests/test_automodsumm.py
+++ b/astropy_helpers/sphinx/ext/tests/test_automodsumm.py
@@ -35,9 +35,9 @@ class FakeApp(object):
         self.builder = FakeBuilder(srcdir=srcdir)
         self.info = []
         self.warnings = []
-        self._extensions = []
+        self.extensions = []
         if automodapipresent:
-            self._extensions.append('astropy_helpers.sphinx.ext.automodapi')
+            self.extensions.append('astropy_helpers.sphinx.ext.automodapi')
 
     def info(self, msg, loc):
         self.info.append((msg, loc))


### PR DESCRIPTION
This is basically the backport of https://github.com/astropy/sphinx-automodapi/pull/22 to v1.3.x here.

@astrofrog: I've realized that while v2.0 is not far away, but there may be packages that don't want or can't upgrade for that due to API changes in astropy, etc. So releasing a 1.3.2 of helpers can be useful.