### PR TITLE
 Removing python2.6 and python3.3 workarounds

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -878,46 +878,6 @@ class _AHBootstrapSystemExit(SystemExit):
         super(_AHBootstrapSystemExit, self).__init__(msg, *args[1:])
 
 
-if sys.version_info[:2] < (2, 7):
-    # In Python 2.6 the distutils log does not log warnings, errors, etc. to
-    # stderr so we have to wrap it to ensure consistency at least in this
-    # module
-    import distutils
-
-    class log(object):
-        def __getattr__(self, attr):
-            return getattr(distutils.log, attr)
-
-        def warn(self, msg, *args):
-            self._log_to_stderr(distutils.log.WARN, msg, *args)
-
-        def error(self, msg):
-            self._log_to_stderr(distutils.log.ERROR, msg, *args)
-
-        def fatal(self, msg):
-            self._log_to_stderr(distutils.log.FATAL, msg, *args)
-
-        def log(self, level, msg, *args):
-            if level in (distutils.log.WARN, distutils.log.ERROR,
-                         distutils.log.FATAL):
-                self._log_to_stderr(level, msg, *args)
-            else:
-                distutils.log.log(level, msg, *args)
-
-        def _log_to_stderr(self, level, msg, *args):
-            # This is the only truly 'public' way to get the current threshold
-            # of the log
-            current_threshold = distutils.log.set_threshold(distutils.log.WARN)
-            distutils.log.set_threshold(current_threshold)
-            if level >= current_threshold:
-                if args:
-                    msg = msg % args
-                sys.stderr.write('%s\n' % msg)
-                sys.stderr.flush()
-
-    log = log()
-
-
 BOOTSTRAPPER = _Bootstrapper.main()
 
 

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -230,11 +230,7 @@ def test_installed_git_version(version_test_package, version, tmpdir, capsys):
             loader = pkgutil.get_loader('apyhtest_eva')
             # Ensure we are importing the 'packagename' that was just unpacked
             # into the build_dir
-            if sys.version_info[:2] != (3, 3):
-                # Skip this test on Python 3.3 wherein the SourceFileLoader
-                # has a bug where get_filename() does not return an absolute
-                # path
-                assert loader.get_filename().startswith(str(build_dir))
+            assert loader.get_filename().startswith(str(build_dir))
             assert apyhtest_eva.__githash__ == githash
         finally:
             cleanup_import('apyhtest_eva')

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -408,24 +408,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         the function object.
         """
         if isinstance(func, method_types):
-            try:
-                func = func.__func__
-            except AttributeError:
-                # classmethods in Python2.6 and below lack the __func__
-                # attribute so we need to hack around to get it
-                method = func.__get__(None, object)
-                if isinstance(method, types.FunctionType):
-                    # For staticmethods anyways the wrapped object is just a
-                    # plain function (not a bound method or anything like that)
-                    func = method
-                elif hasattr(method, '__func__'):
-                    func = method.__func__
-                elif hasattr(method, 'im_func'):
-                    func = method.im_func
-                else:
-                    # Nothing we can do really...  just return the original
-                    # classmethod, etc.
-                    return func
+            func = func.__func__
         return func
 
     def deprecate_function(func, message):


### PR DESCRIPTION
As it was pointed out in #311, there are still a few workarounds for python versions we don't support any more.  
