### PR TITLE
Importing typing to workaround issues with doc builds

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -91,6 +91,17 @@ except:
     use_setuptools()
 
 
+# typing as a dependency for 1.6.1+ Sphinx causes issues when imported after
+# initializing submodule with ah_boostrap.py
+# See discussion and references in
+# https://github.com/astropy/astropy-helpers/issues/302
+
+try:
+    import typing   # noqa
+except ImportError:
+    pass
+
+
 # Note: The following import is required as a workaround to
 # https://github.com/astropy/astropy-helpers/issues/89; if we don't import this
 # module now, it will get cleaned up after `run_setup` is called, but that will


### PR DESCRIPTION
This workaround should fix the issues we saw relating to the new 1.6.1+ sphinx versions, among others in #302 and https://github.com/sphinx-doc/sphinx/issues/3766#issuecomment-305280336

The minimalist failing example doesn't even include sphinx. ``typing`` became a dependency of sphinx, but it's only part of python3.6 with a backport package to previous versions. I didn't find where it goes wrong as it wasn't used in the helpers, but importing it at the top seems to provide a workaround.

```
import ah_bootstrap
import typing
import jinja2
```

close #302
