### PR TITLE
Fix warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,10 @@ astropy-helpers Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Address warnings that occur during testing. [#330]
+- The function ``get_git_devstr`` now returns ``'0'`` instead of ``None`` when
+  no git repository is present. This allows generation of development version
+  strings that are in a format that ``setuptools`` expects (e.g. "1.1.3.dev0"
+  instead of "1.1.3.dev"). [#330]
 
 
 2.0.1 (2017-07-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ astropy-helpers Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Address warnings that occur during testing. [#330]
 
 
 2.0.1 (2017-07-28)

--- a/astropy_helpers/git_helpers.py
+++ b/astropy_helpers/git_helpers.py
@@ -90,8 +90,6 @@ def get_git_devstr(sha=False, show_warning=True, path=None):
 
     if path is None:
         path = os.getcwd()
-        if not _get_repo_path(path, levels=0):
-            return ''
 
     if not os.path.isdir(path):
         path = os.path.abspath(os.path.dirname(path))
@@ -135,7 +133,12 @@ def get_git_devstr(sha=False, show_warning=True, path=None):
 
     returncode, stdout, stderr = run_git(cmd)
 
-    if not sha and returncode == 129:
+    if not sha and returncode == 128:
+        # git returns 128 if the command is not run from within a git
+        # repository tree. In this case, a warning is produced above but we
+        # return the default dev version of '0'.
+        return '0'
+    elif not sha and returncode == 129:
         # git returns 129 if a command option failed to parse; in
         # particular this could happen in git versions older than 1.7.2
         # where the --count option is not supported

--- a/astropy_helpers/git_helpers.py
+++ b/astropy_helpers/git_helpers.py
@@ -158,7 +158,9 @@ def get_git_devstr(sha=False, show_warning=True, path=None):
         return _decode_stdio(stdout).strip()
 
 
-def _get_repo_path(pathname, levels=None):
+# This function is tested but it is only ever executed within a subprocess when
+# creating a fake package, so it doesn't get picked up by coverage metrics.
+def _get_repo_path(pathname, levels=None): # pragma: no cover
     """
     Given a file or directory name, determine the root of the git repository
     this path is under.  If given, this won't look any higher than ``levels``

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -241,9 +241,10 @@ def test_installed_git_version(version_test_package, version, tmpdir, capsys):
 
 
 def test_get_git_devstr(tmpdir):
+    dirpath = str(tmpdir)
     with catch_warnings(record=True) as w:
-        devstr = get_git_devstr(path=tmpdir)
+        devstr = get_git_devstr(path=dirpath)
         assert devstr == '0'
         assert len(w) == 1
         assert str(w[0].message).startswith(
-            "No git repository present at local('{}')".format(tmpdir))
+            "No git repository present at '{}'".format(dirpath))

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -242,9 +242,13 @@ def test_installed_git_version(version_test_package, version, tmpdir, capsys):
 
 def test_get_git_devstr(tmpdir):
     dirpath = str(tmpdir)
+    warn_msg = "No git repository present at"
+    # Verify as much as possible, but avoid dealing with paths on windows
+    if not sys.platform.startswith('win'):
+        warn_msg += " '{}'".format(dirpath)
+
     with catch_warnings(record=True) as w:
         devstr = get_git_devstr(path=dirpath)
         assert devstr == '0'
         assert len(w) == 1
-        assert str(w[0].message).startswith(
-            "No git repository present at '{}'".format(dirpath))
+        assert str(w[0].message).startswith(warn_msg)

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -37,10 +37,10 @@ from astropy_helpers.version_helpers import generate_version_py
 
 if not RELEASE:
     VERSION += get_git_devstr(False)
-    # This workaround is required to account for the fact that when we test
-    # installation of this package in test_installed_git_version (even with
-    # development versions), in which case get_git_devstr will not work
-    # since we will be outside of a git repository.
+    # This workaround is required to account for the fact that we test
+    # installation of this package in test_installed_git_version even with
+    # development versions. In these cases get_git_devstr does not work since
+    # it is called from outside of a git repository.
     if VERSION.endswith('.dev'):
         VERSION = VERSION.replace('.dev', '')
 
@@ -80,6 +80,7 @@ def version_test_package(tmpdir, request):
             cleanup_import('apyhtest_eva')
 
         request.addfinalizer(finalize)
+
         return test_package
 
     return make_test_package

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -37,6 +37,12 @@ from astropy_helpers.version_helpers import generate_version_py
 
 if not RELEASE:
     VERSION += get_git_devstr(False)
+    # This workaround is required to account for the fact that when we test
+    # installation of this package in test_installed_git_version (even with
+    # development versions), in which case get_git_devstr will not work
+    # since we will be outside of a git repository.
+    if VERSION.endswith('.dev'):
+        VERSION = VERSION.replace('.dev', '')
 
 generate_version_py(NAME, VERSION, RELEASE, False, uses_git=not RELEASE)
 
@@ -74,7 +80,6 @@ def version_test_package(tmpdir, request):
             cleanup_import('apyhtest_eva')
 
         request.addfinalizer(finalize)
-
         return test_package
 
     return make_test_package

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -2,6 +2,7 @@ import os
 import sys
 import stat
 import shutil
+import warnings
 import contextlib
 
 import pytest
@@ -12,6 +13,7 @@ from setuptools import Distribution
 
 from ..setup_helpers import get_package_info, register_commands
 from ..commands import build_ext
+from ..utils import AstropyDeprecationWarning
 
 from . import reset_setup_helpers, reset_distutils_log, fix_hide_setuptools  # noqa
 from . import run_setup, cleanup_import
@@ -323,7 +325,8 @@ def test_build_docs(tmpdir, mode):
         elif mode == 'cli-l':
             run_setup('setup.py', ['build_docs', '-l'])
         elif mode == 'deprecated':
-            run_setup('setup.py', ['build_sphinx'])
+            with pytest.warns(AstropyDeprecationWarning):
+                run_setup('setup.py', ['build_sphinx'])
         elif mode == 'direct':  # to check coverage
             with docs_dir.as_cwd():
                 from sphinx import main

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import six
 import stat
 import shutil
 import warnings
@@ -18,6 +17,10 @@ from ..utils import AstropyDeprecationWarning
 
 from . import reset_setup_helpers, reset_distutils_log, fix_hide_setuptools  # noqa
 from . import run_setup, cleanup_import
+
+
+# Determine whether we're in a PY2 environment without using six
+USING_PY2 = sys.version_info < (3,0,0)
 
 
 def _extension_test_package(tmpdir, request, extension_type='c'):
@@ -181,7 +184,7 @@ def test_compiler_module(c_extension_test_package):
                        '--record={0}'.format(install_temp.join('record.txt'))])
         # Skip this portion of the test on windows systems with Py 2.7 since
         # it is known to produce additional warnings.
-        if not (six.PY2 or sys.platform.startswith('win')):
+        if not (USING_PY2 or sys.platform.startswith('win')):
             # Warning expected from get_git_devstr, called by generate_version_py
             assert len(w) == 1
             assert str(w[0].message).startswith("No git repository present at")
@@ -218,7 +221,7 @@ def test_no_cython_buildext(c_extension_test_package, monkeypatch):
         with warnings.catch_warnings(record=True) as w:
             run_setup('setup.py', ['build_ext', '--inplace'])
         # Warning expected from get_git_devstr, called by generate_version_py
-        if not six.PY2:
+        if not USING_PY2:
             assert len(w) == 1
             assert str(w[0].message).startswith("No git repository present at")
 
@@ -252,7 +255,7 @@ def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
             with warnings.catch_warnings(record=True) as w:
                 run_setup('setup.py', ['build_ext', '--inplace'])
             # Warning expected from get_git_devstr, called by generate_version_py
-            if not six.PY2:
+            if not USING_PY2:
                 assert len(w) == 1
                 assert str(w[0].message).startswith(
                     "No git repository present at")

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -181,7 +181,7 @@ def test_compiler_module(c_extension_test_package):
                        '--record={0}'.format(install_temp.join('record.txt'))])
         # Skip this portion of the test on windows systems with Py 2.7 since
         # it is known to produce additional warnings.
-        if not (six.PY2 and sys.platform.startswith('win')):
+        if not (six.PY2 or sys.platform.startswith('win')):
             # Warning expected from get_git_devstr, called by generate_version_py
             assert len(w) == 1
             assert str(w[0].message).startswith("No git repository present at")
@@ -218,8 +218,9 @@ def test_no_cython_buildext(c_extension_test_package, monkeypatch):
         with warnings.catch_warnings(record=True) as w:
             run_setup('setup.py', ['build_ext', '--inplace'])
         # Warning expected from get_git_devstr, called by generate_version_py
-        assert len(w) == 1
-        assert str(w[0].message).startswith("No git repository present at")
+        if not six.PY2:
+            assert len(w) == 1
+            assert str(w[0].message).startswith("No git repository present at")
 
     sys.path.insert(0, str(test_pkg))
 
@@ -251,8 +252,10 @@ def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
             with warnings.catch_warnings(record=True) as w:
                 run_setup('setup.py', ['build_ext', '--inplace'])
             # Warning expected from get_git_devstr, called by generate_version_py
-            assert len(w) == 1
-            assert str(w[0].message).startswith("No git repository present at")
+            if not six.PY2:
+                assert len(w) == 1
+                assert str(w[0].message).startswith(
+                    "No git repository present at")
 
     msg = ('Could not find C/C++ file '
            '{0}.(c/cpp)'.format('apyhtest_eva/unit02'.replace('/', os.sep)))

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import six
 import stat
 import shutil
 import warnings
@@ -178,9 +179,12 @@ def test_compiler_module(c_extension_test_package):
                        '--single-version-externally-managed',
                        '--install-lib={0}'.format(install_temp),
                        '--record={0}'.format(install_temp.join('record.txt'))])
-        # Warning expected from get_git_devstr, called by generate_version_py
-        assert len(w) == 1
-        assert str(w[0].message).startswith("No git repository present at")
+        # Skip this portion of the test on windows systems with Py 2.7 since
+        # it is known to produce additional warnings.
+        if not (six.PY2 and sys.platform.startswith('win')):
+            # Warning expected from get_git_devstr, called by generate_version_py
+            assert len(w) == 1
+            assert str(w[0].message).startswith("No git repository present at")
 
     with install_temp.as_cwd():
         import apyhtest_eva

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -172,11 +172,15 @@ def test_compiler_module(c_extension_test_package):
     with test_pkg.as_cwd():
         # This is one of the simplest ways to install just a package into a
         # test directory
-        run_setup('setup.py',
-                  ['install',
-                   '--single-version-externally-managed',
-                   '--install-lib={0}'.format(install_temp),
-                   '--record={0}'.format(install_temp.join('record.txt'))])
+        with warnings.catch_warnings(record=True) as w:
+            run_setup('setup.py',
+                      ['install',
+                       '--single-version-externally-managed',
+                       '--install-lib={0}'.format(install_temp),
+                       '--record={0}'.format(install_temp.join('record.txt'))])
+        # Warning expected from get_git_devstr, called by generate_version_py
+        assert len(w) == 1
+        assert str(w[0].message).startswith("No git repository present at")
 
     with install_temp.as_cwd():
         import apyhtest_eva
@@ -207,7 +211,11 @@ def test_no_cython_buildext(c_extension_test_package, monkeypatch):
                         lambda *args: False)
 
     with test_pkg.as_cwd():
-        run_setup('setup.py', ['build_ext', '--inplace'])
+        with warnings.catch_warnings(record=True) as w:
+            run_setup('setup.py', ['build_ext', '--inplace'])
+        # Warning expected from get_git_devstr, called by generate_version_py
+        assert len(w) == 1
+        assert str(w[0].message).startswith("No git repository present at")
 
     sys.path.insert(0, str(test_pkg))
 
@@ -236,7 +244,11 @@ def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
 
     with test_pkg.as_cwd():
         with pytest.raises(SystemExit) as exc_info:
-            run_setup('setup.py', ['build_ext', '--inplace'])
+            with warnings.catch_warnings(record=True) as w:
+                run_setup('setup.py', ['build_ext', '--inplace'])
+            # Warning expected from get_git_devstr, called by generate_version_py
+            assert len(w) == 1
+            assert str(w[0].message).startswith("No git repository present at")
 
     msg = ('Could not find C/C++ file '
            '{0}.(c/cpp)'.format('apyhtest_eva/unit02'.replace('/', os.sep)))


### PR DESCRIPTION
This partially addresses #317. In particular, these two warnings no longer occur:

>astropy_helpers/tests/test_git_helpers.py::test_installed_git_version[1.0.dev]
>
>  /Users/travis/miniconda/envs/test/lib/python2.7/site-packages/setuptools-27.2.0-py2.7.egg/setuptools/dist.py:331: UserWarning: Normalizing '1.0.dev' to '1.0.dev0'
>
> astropy_helpers/tests/test_setup_helpers.py::test_build_docs[deprecated]
>
> /Users/travis/build/bsipocz/astropy-helpers/astropy_helpers/commands/build_sphinx.py:259: AstropyDeprecationWarning: The "build_sphinx" command is now deprecated. Use"build_docs" instead.
>
>    '"build_docs" instead.', AstropyDeprecationWarning)

I wasn't able to reproduce the other warnings on my own system, so I'm not sure whether they only occur in particular environments or whether they have already been resolved.