### PR TITLE
Fix broken package exclusion caching behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,10 @@ astropy-helpers Changelog
 
 - Switch to using mathjax instead of imgmath for local builds. [#342]
 
+- Deprecate ``exclude`` parameter of various functions in setup_helpers since
+  it could not work as intended. Add new function ``add_exclude_packages`` to
+  provide intended behavior. [#331]
+
 2.0.1 (2017-07-28)
 ------------------
 


### PR DESCRIPTION
Taking a crack at fixing #329. Feedback is welcome on whether this is a reasonable fix or whether we should use another approach. If this seems reasonable, it's probably a good idea to add another test to make sure the package exclusion mechanism actually works.

This is a bit touchy because it involves user-facing APIs that don't actually work as expected. I added deprecation warnings for the affected parameters but they really shouldn't be used at all because they don't work. Maybe someone else has a better idea of how to handle this.