### PR TITLE
Allow Sphinx doctest extension to recognize standard doctest directives

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ astropy-helpers Changelog
   it could not work as intended. Add new function ``add_exclude_packages`` to
   provide intended behavior. [#331]
 
+- Allow custom Sphinx doctest extension to recognize and process standard
+  doctest directives ``testsetup`` and ``doctest``. [#335]
+
 2.0.1 (2017-07-28)
 ------------------
 

--- a/astropy_helpers/sphinx/ext/doctest.py
+++ b/astropy_helpers/sphinx/ext/doctest.py
@@ -37,6 +37,7 @@ def setup(app):
     app.add_directive('doctest-requires', DoctestRequiresDirective)
     app.add_directive('doctest-skip', DoctestSkipDirective)
     app.add_directive('doctest-skip-all', DoctestSkipDirective)
+    app.add_directive('doctest', DoctestSkipDirective)
 
     return {'parallel_read_safe': True,
             'parallel_write_safe': True}

--- a/astropy_helpers/sphinx/ext/doctest.py
+++ b/astropy_helpers/sphinx/ext/doctest.py
@@ -26,6 +26,14 @@ class DoctestSkipDirective(Directive):
         return [literal_block(code, code)]
 
 
+class DoctestOmitDirective(Directive):
+    has_content = True
+
+    def run(self):
+        # Simply do not add any content when this directive is encountered
+        return []
+
+
 class DoctestRequiresDirective(DoctestSkipDirective):
     # This is silly, but we really support an unbounded number of
     # optional arguments
@@ -38,6 +46,7 @@ def setup(app):
     app.add_directive('doctest-skip', DoctestSkipDirective)
     app.add_directive('doctest-skip-all', DoctestSkipDirective)
     app.add_directive('doctest', DoctestSkipDirective)
+    app.add_directive('testsetup', DoctestOmitDirective)
 
     return {'parallel_read_safe': True,
             'parallel_write_safe': True}

--- a/astropy_helpers/sphinx/ext/doctest.py
+++ b/astropy_helpers/sphinx/ext/doctest.py
@@ -46,6 +46,10 @@ def setup(app):
     app.add_directive('doctest-skip', DoctestSkipDirective)
     app.add_directive('doctest-skip-all', DoctestSkipDirective)
     app.add_directive('doctest', DoctestSkipDirective)
+    # Code blocks that use this directive will not appear in the generated
+    # documentation. This is intended to hide boilerplate code that is only
+    # useful for testing documentation using doctest, but does not actually
+    # belong in the documentation itself.
     app.add_directive('testsetup', DoctestOmitDirective)
 
     return {'parallel_read_safe': True,


### PR DESCRIPTION
I started looking at https://github.com/astropy/astropy/issues/6010 and realized that it would be quite useful to be able to use the doctest directives `testsetup` and `doctest`. However, when building the documentation, Sphinx doesn't recognize these directives since we're not actually using  the Sphinx doctest plugin, but a simple custom extension that we provide ourselves.

This is a fairly simple change that allows the `testsetup` and `doctest` directives to be recognized and handled properly when building Sphinx documentation. It's not exhaustive since I don't have a need for the other cases at the moment. However, it doesn't seem difficult to add support for [the others](http://www.sphinx-doc.org/en/stable/ext/doctest.html#directives) as well.