### PR TITLE
Allow to override build date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ astropy-helpers Changelog
   strings that are in a format that ``setuptools`` expects (e.g. "1.1.3.dev0"
   instead of "1.1.3.dev"). [#330]
 
+- It is now possible to override generated timestamps to make builds
+  reproducible by setting the ``SOURCE_DATE_EPOCH`` environment variable [#341]
 
 2.0.1 (2017-07-28)
 ------------------

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -25,6 +25,7 @@ import imp
 import os
 import pkgutil
 import sys
+import time
 
 from distutils import log
 
@@ -142,7 +143,8 @@ githash = "{githash}"
 
 def _get_version_py_str(packagename, version, githash, release, debug,
                         uses_git=True):
-    timestamp = datetime.datetime.now()
+    epoch = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+    timestamp = datetime.datetime.utcfromtimestamp(epoch)
     major, minor, bugfix = _version_split(version)
 
     if packagename.lower() == 'astropy':


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Without this patch, the python-sunpy openSUSE package differed
for every build