### PR TITLE
Use mathjax instead of imgmath

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ astropy-helpers Changelog
 
 - Mark Sphinx extensions as parallel-safe. [#344]
 
+- Switch to using mathjax instead of imgmath for local builds. [#342]
+
 2.0.1 (2017-07-28)
 ------------------
 

--- a/astropy_helpers/sphinx/conf.py
+++ b/astropy_helpers/sphinx/conf.py
@@ -154,13 +154,6 @@ if not on_rtd and LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
 else:
     extensions.append('sphinx.ext.mathjax')
 
-
-# Above, we use a patched version of viewcode rather than 'sphinx.ext.viewcode'
-# This can be changed to the sphinx version once the following issue is fixed
-# in sphinx:
-# https://bitbucket.org/birkenfeld/sphinx/issue/623/
-# extension-viewcode-fails-with-function
-
 try:
     import matplotlib.sphinxext.plot_directive
     extensions += [matplotlib.sphinxext.plot_directive.__name__]

--- a/astropy_helpers/sphinx/conf.py
+++ b/astropy_helpers/sphinx/conf.py
@@ -149,12 +149,10 @@ extensions = [
     'astropy_helpers.sphinx.ext.changelog_links']
 
 
-if on_rtd:
-    extensions.append('sphinx.ext.mathjax')
-elif LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
+if not on_rtd and LooseVersion(sphinx.__version__) < LooseVersion('1.4'):
     extensions.append('sphinx.ext.pngmath')
 else:
-    extensions.append('sphinx.ext.imgmath')
+    extensions.append('sphinx.ext.mathjax')
 
 
 # Above, we use a patched version of viewcode rather than 'sphinx.ext.viewcode'


### PR DESCRIPTION
We currently use mathjax on RTD but we use imgmath locally (this is to render latex equations). Using imgmath requires LaTeX to be installed in order for the docs to be built, and is slower - the astropy docs build in **5m14s** with mathjax instead of **6m40s** on my laptop, which is not negligible (these timings don't include the sphinx-gallery time since I don't have the plugin installed).

One might argue that imgmath looks nicer in some cases because it uses the real LaTeX, but this isn't important since at the end of the day what users see is the mathjax rendered LaTeX on RTD. So I am proposing we switch to also using mathjax locally and then remove the LaTeX requirements for building the docs (which we mention in http://docs.astropy.org/en/stable/install.html#building-documentation). This will then also make the local build consistent with RTD.

I also removed an unrelated obsolete comment since we do use ``sphinx.ext.viewcode`` now.