### PR TITLE
Mark sphinx extensions as parallel-safe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ astropy-helpers Changelog
 - It is now possible to override generated timestamps to make builds
   reproducible by setting the ``SOURCE_DATE_EPOCH`` environment variable [#341]
 
+- Mark Sphinx extensions as parallel-safe. [#344]
+
 2.0.1 (2017-07-28)
 ------------------
 

--- a/astropy_helpers/sphinx/ext/changelog_links.py
+++ b/astropy_helpers/sphinx/ext/changelog_links.py
@@ -72,7 +72,11 @@ def setup_patterns_rexes(app):
 
 
 def setup(app):
+
     app.connect('doctree-resolved', process_changelog_links)
     app.connect('builder-inited', setup_patterns_rexes)
     app.add_config_value('github_issues_url', None, True)
     app.add_config_value('changelog_links_docpattern', ['.*changelog.*', 'whatsnew/.*'], True)
+
+    return {'parallel_read_safe': True,
+            'parallel_write_safe': True}

--- a/astropy_helpers/sphinx/ext/doctest.py
+++ b/astropy_helpers/sphinx/ext/doctest.py
@@ -33,6 +33,10 @@ class DoctestRequiresDirective(DoctestSkipDirective):
 
 
 def setup(app):
+
     app.add_directive('doctest-requires', DoctestRequiresDirective)
     app.add_directive('doctest-skip', DoctestSkipDirective)
     app.add_directive('doctest-skip-all', DoctestSkipDirective)
+
+    return {'parallel_read_safe': True,
+            'parallel_write_safe': True}

--- a/astropy_helpers/sphinx/ext/edit_on_github.py
+++ b/astropy_helpers/sphinx/ext/edit_on_github.py
@@ -147,6 +147,7 @@ def html_page_context(app, pagename, templatename, context, doctree):
 
 
 def setup(app):
+
     app.add_config_value('edit_on_github_project', 'REQUIRED', True)
     app.add_config_value('edit_on_github_branch', 'master', True)
     app.add_config_value('edit_on_github_source_root', 'lib', True)
@@ -162,3 +163,6 @@ def setup(app):
 
     app.connect('doctree-read', doctree_read)
     app.connect('html-page-context', html_page_context)
+
+    return {'parallel_read_safe': True,
+            'parallel_write_safe': True}

--- a/astropy_helpers/sphinx/ext/tocdepthfix.py
+++ b/astropy_helpers/sphinx/ext/tocdepthfix.py
@@ -15,4 +15,8 @@ def fix_toc_entries(app, doctree):
 
 
 def setup(app):
+
     app.connect('doctree-read', fix_toc_entries)
+
+    return {'parallel_read_safe': True,
+            'parallel_write_safe': True}


### PR DESCRIPTION
Sphinx now requires this (in order to use parallel mode). I checked over the code and as far as I can tell these should indeed be parallel safe. For sphinx-automodapi it is more complicated, and I'll copy over code from there once https://github.com/astropy/sphinx-automodapi/pull/38 is merged and I've made a release.