### PR TITLE
Added a helper function to add OpenMP compilation flags if available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ astropy-helpers Changelog
 - Removing deprecated _test_compat making astropy a hard dependency for
   packages wishing to use the astropy tests machinery. [#314]
 
+- Added new helper function add_openmp_flags_if_available that can add
+  OpenMP compilation flags to a C/Cython extension if needed. [#346]
+
 - Removing unused 'register' command since packages should be uploaded
   with twine and get registered automatically. [#332]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,14 +7,14 @@ astropy-helpers Changelog
 - Removing deprecated _test_compat making astropy a hard dependency for
   packages wishing to use the astropy tests machinery. [#314]
 
-- Added new helper function add_openmp_flags_if_available that can add
-  OpenMP compilation flags to a C/Cython extension if needed. [#346]
-
 - Removing unused 'register' command since packages should be uploaded
   with twine and get registered automatically. [#332]
 
 2.0.2 (unreleased)
 ------------------
+
+- Added new helper function add_openmp_flags_if_available that can add
+  OpenMP compilation flags to a C/Cython extension if needed. [#346]
 
 - Update numpydoc to v0.7. [#343]
 

--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -71,9 +71,11 @@ def add_openmp_flags_if_available(extension):
     start_dir = os.path.abspath('.')
 
     if get_compiler_option() == 'msvc':
-        flag = '-openmp'
+        compile_flag = '-openmp'
+        link_flag = ''
     else:
-        flag = '-fopenmp'
+        compile_flag = '-fopenmp'
+        link_flag = '-fopenmp'
 
     try:
 
@@ -83,8 +85,8 @@ def add_openmp_flags_if_available(extension):
             f.write(CCODE)
 
         # Compile, link, and run test program
-        ccompiler.compile(['test_openmp.c'], output_dir='.', extra_postargs=[flag])
-        ccompiler.link_executable(['test_openmp.o'], 'test_openmp', extra_postargs=[flag])
+        ccompiler.compile(['test_openmp.c'], output_dir='.', extra_postargs=[compile_flag])
+        ccompiler.link_executable(['test_openmp.o'], 'test_openmp', extra_postargs=[link_flag])
         output = subprocess.check_output('./test_openmp').decode('utf-8').splitlines()
 
         if 'nthreads=' in output[0]:
@@ -109,10 +111,9 @@ def add_openmp_flags_if_available(extension):
         os.chdir(start_dir)
 
     if using_openmp:
-        log.info("Compiling Cython extension with OpenMP support (using {0} flag)".format(flag))
-        extension.extra_compile_args.append(flag)
-        if get_compiler_option() != 'msvc':
-            extension.extra_link_args.append(flag)
+        log.info("Compiling Cython extension with OpenMP support")
+        extension.extra_compile_args.append(compile_flag)
+        extension.extra_link_args.append(link_flag)
     else:
         log.warn("Cannot compile Cython extension with OpenMP, reverting to non-parallel code")
 

--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -33,6 +33,7 @@
 from __future__ import absolute_import, print_function
 
 import os
+import glob
 import tempfile
 import subprocess
 
@@ -84,9 +85,11 @@ def add_openmp_flags_if_available(extension):
         with open('test_openmp.c', 'w') as f:
             f.write(CCODE)
 
+        os.mkdir('objects')
+
         # Compile, link, and run test program
-        ccompiler.compile(['test_openmp.c'], output_dir='.', extra_postargs=[compile_flag])
-        ccompiler.link_executable(['test_openmp.o'], 'test_openmp', extra_postargs=[link_flag])
+        ccompiler.compile(['test_openmp.c'], output_dir='objects', extra_postargs=[compile_flag])
+        ccompiler.link_executable(glob.glob(os.path.join('objects', '*')), 'test_openmp', extra_postargs=[link_flag])
         output = subprocess.check_output('./test_openmp').decode('utf-8').splitlines()
 
         if 'nthreads=' in output[0]:

--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -39,7 +39,7 @@ import subprocess
 from distutils import log
 from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler
-from distutils.errors import CompileError
+from distutils.errors import CompileError, LinkError
 
 from .setup_helpers import get_compiler_option
 
@@ -100,7 +100,7 @@ def add_openmp_flags_if_available(extension):
                      "program (output was {0})".format(output))
             using_openmp = False
 
-    except CompileError:
+    except (CompileError, LinkError):
 
         using_openmp = False
 
@@ -111,7 +111,8 @@ def add_openmp_flags_if_available(extension):
     if using_openmp:
         log.info("Compiling Cython extension with OpenMP support (using {0} flag)".format(flag))
         extension.extra_compile_args.append(flag)
-        extension.extra_link_args.append(flag)
+        if get_compiler_option() != 'msvc':
+            extension.extra_link_args.append(flag)
     else:
         log.warn("Cannot compile Cython extension with OpenMP, reverting to non-parallel code")
 

--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -1,0 +1,118 @@
+# This module defines functions that can be used to check whether OpenMP is
+# available and if so what flags to use.
+
+# This file includes code adapted from astroscrappy, originally released under
+# the following license:
+#
+# Copyright (c) 2015, Curtis McCully
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice, this
+#   list of conditions and the following disclaimer in the documentation and/or
+#   other materials provided with the distribution.
+# * Neither the name of the Astropy Team nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, print_function
+
+import os
+import tempfile
+import subprocess
+
+from distutils import log
+from distutils.ccompiler import new_compiler
+from distutils.sysconfig import customize_compiler
+from distutils.errors import CompileError
+
+from .setup_helpers import get_compiler_option
+
+__all__ = ['add_openmp_flags_if_available']
+
+
+def add_openmp_flags_if_available(extension):
+    """
+    Add OpenMP compilation flags, if available (if not a warning will be
+    printed to the console and no flags will be added)
+
+    Returns `True` if the flags were added, `False` otherwise.
+    """
+
+    ccompiler = new_compiler()
+    customize_compiler(ccompiler)
+
+    tmp_dir = tempfile.mkdtemp()
+
+    CCODE = """
+    #include <omp.h>
+    #include <stdio.h>
+    int main() {
+    #pragma omp parallel
+    printf("nthreads=%d\\n", omp_get_num_threads());
+    }
+    """
+
+    start_dir = os.path.abspath('.')
+
+    if get_compiler_option() == 'msvc':
+        flag = '-openmp'
+    else:
+        flag = '-fopenmp'
+
+    try:
+
+        os.chdir(tmp_dir)
+
+        with open('test_openmp.c', 'w') as f:
+            f.write(CCODE)
+
+        # Compile, link, and run test program
+        ccompiler.compile(['test_openmp.c'], output_dir='.', extra_postargs=[flag])
+        ccompiler.link_executable(['test_openmp.o'], 'test_openmp', extra_postargs=[flag])
+        output = subprocess.check_output('./test_openmp').decode('utf-8').splitlines()
+
+        if 'nthreads=' in output[0]:
+            nthreads = int(output[0].strip().split('=')[1])
+            if len(output) == nthreads:
+                using_openmp = True
+            else:
+                log.warn("Unexpected number of lines from output of test OpenMP "
+                         "program (output was {0})".format(output))
+                using_openmp = False
+        else:
+            log.warn("Unexpected output from test OpenMP "
+                     "program (output was {0})".format(output))
+            using_openmp = False
+
+    except CompileError:
+
+        using_openmp = False
+
+    finally:
+
+        os.chdir(start_dir)
+
+    if using_openmp:
+        log.info("Compiling Cython extension with OpenMP support (using {0} flag)".format(flag))
+        extension.extra_compile_args.append(flag)
+        extension.extra_link_args.append(flag)
+    else:
+        log.warn("Cannot compile Cython extension with OpenMP, reverting to non-parallel code")
+
+    return using_openmp

--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -10,39 +10,11 @@
 #     add_openmp_flags_if_available(extension)
 #
 # this will add the OpenMP flags if available.
-#
-# This file includes code heavily adapted from astroscrappy, originally released
-# under the following license:
-#
-# Copyright (c) 2015, Curtis McCully
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without modification,
-# are permitted provided that the following conditions are met:
-#
-# * Redistributions of source code must retain the above copyright notice, this
-#   list of conditions and the following disclaimer.
-# * Redistributions in binary form must reproduce the above copyright notice, this
-#   list of conditions and the following disclaimer in the documentation and/or
-#   other materials provided with the distribution.
-# * Neither the name of the Astropy Team nor the names of its contributors may be
-#   used to endorse or promote products derived from this software without
-#   specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import absolute_import, print_function
 
 import os
+import sys
 import glob
 import tempfile
 import subprocess
@@ -100,7 +72,7 @@ def add_openmp_flags_if_available(extension):
         # Compile, link, and run test program
         ccompiler.compile(['test_openmp.c'], output_dir='objects', extra_postargs=[compile_flag])
         ccompiler.link_executable(glob.glob(os.path.join('objects', '*')), 'test_openmp', extra_postargs=[link_flag])
-        output = subprocess.check_output('./test_openmp').decode('utf-8').splitlines()
+        output = subprocess.check_output('./test_openmp').decode(sys.stdout.encoding).splitlines()
 
         if 'nthreads=' in output[0]:
             nthreads = int(output[0].strip().split('=')[1])

--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -1,8 +1,18 @@
 # This module defines functions that can be used to check whether OpenMP is
-# available and if so what flags to use.
-
-# This file includes code adapted from astroscrappy, originally released under
-# the following license:
+# available and if so what flags to use. To use this, import the
+# add_openmp_flags_if_available function in a setup_package.py file where you
+# are defining your extensions:
+#
+#     from astropy_helpers.openmp_helpers import add_openmp_flags_if_available
+#
+# then call it with a single extension as the only argument:
+#
+#     add_openmp_flags_if_available(extension)
+#
+# this will add the OpenMP flags if available.
+#
+# This file includes code heavily adapted from astroscrappy, originally released
+# under the following license:
 #
 # Copyright (c) 2015, Curtis McCully
 # All rights reserved.

--- a/astropy_helpers/tests/test_openmp_helpers.py
+++ b/astropy_helpers/tests/test_openmp_helpers.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from copy import deepcopy
 from distutils.core import Extension
 
@@ -7,6 +8,7 @@ from ..setup_helpers import _module_state, register_commands
 
 IS_TRAVIS_LINUX = os.environ.get('TRAVIS_OS_NAME', None) == 'linux'
 IS_APPVEYOR = os.environ.get('APPVEYOR', None) == 'True'
+PY3_LT_35 = sys.version_info[0] == 3 and sys.version_info[1] < 5
 
 _state = None
 
@@ -31,5 +33,6 @@ def test_add_openmp_flags_if_available():
     # MacOS X usually it will not work but this will depend on the compiler).
     # Having this is useful because we'll find out if OpenMP no longer works
     # for any reason on platforms on which it does work at the time of writing.
-    if IS_TRAVIS_LINUX or IS_APPVEYOR:
+    # OpenMP doesn't work on Python 3.x where x<5 on AppVeyor though.
+    if IS_TRAVIS_LINUX or (IS_APPVEYOR and not PY3_LT_35):
         assert using_openmp

--- a/astropy_helpers/tests/test_openmp_helpers.py
+++ b/astropy_helpers/tests/test_openmp_helpers.py
@@ -1,0 +1,22 @@
+import os
+from distutils.core import Extension
+
+from ..openmp_helpers import add_openmp_flags_if_available
+from ..setup_helpers import register_commands
+
+IS_TRAVIS_LINUX = os.environ.get('TRAVIS_OS_NAME', None) == 'linux'
+IS_APPVEYOR = os.environ.get('APPVEYOR', None) == 'True'
+
+
+def test_add_openmp_flags_if_available():
+
+    register_commands('yoda', '0.0', False)
+
+    using_openmp = add_openmp_flags_if_available(Extension('test', []))
+
+    # Make sure that on Travis (Linux) and AppVeyor OpenMP does get used (for
+    # MacOS X usually it will not work but this will depend on the compiler).
+    # Having this is useful because we'll find out if OpenMP no longer works
+    # for any reason on platforms on which it does work at the time of writing.
+    if IS_TRAVIS_LINUX or IS_APPVEYOR:
+        assert using_openmp

--- a/astropy_helpers/tests/test_openmp_helpers.py
+++ b/astropy_helpers/tests/test_openmp_helpers.py
@@ -1,16 +1,29 @@
 import os
+from copy import deepcopy
 from distutils.core import Extension
 
 from ..openmp_helpers import add_openmp_flags_if_available
-from ..setup_helpers import register_commands
+from ..setup_helpers import _module_state, register_commands
 
 IS_TRAVIS_LINUX = os.environ.get('TRAVIS_OS_NAME', None) == 'linux'
 IS_APPVEYOR = os.environ.get('APPVEYOR', None) == 'True'
 
+_state = None
+
+
+def setup_function(function):
+    global state
+    state = deepcopy(_module_state)
+
+
+def teardown_function(function):
+    _module_state.clear()
+    _module_state.update(state)
+
 
 def test_add_openmp_flags_if_available():
 
-    register_commands('yoda', '0.0', False)
+    register_commands('openmp_testing', '0.0', False)
 
     using_openmp = add_openmp_flags_if_available(Extension('test', []))
 

--- a/licenses/LICENSE_ASTROSCRAPPY.rst
+++ b/licenses/LICENSE_ASTROSCRAPPY.rst
@@ -1,0 +1,28 @@
+# The OpenMP helpers include code heavily adapted from astroscrappy, released
+# under the following license:
+#
+# Copyright (c) 2015, Curtis McCully
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice, this
+#   list of conditions and the following disclaimer in the documentation and/or
+#   other materials provided with the distribution.
+# * Neither the name of the Astropy Team nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This was originally based on a function by @cmccully in astroscrappy but rewritten to also test linking and running of the test code. The approach here is to make a function that modifies the extension, which seems the most convenient. Packages can then import this function in a ``setup_package.py`` and patch extensions. This function is made to fail non-catastrophically if OpenMP flags are not available (a warning is emitted and the function returns False). In the tests I've hard coded that we expect this to pass on Travis Linux and AppVeyor by default otherwise we have no way of knowing this is working for sure.

Note that the test here is a little more stringent because it checks not just compilation but also linking and running the test program, which I believe is important to make sure things run ok end-to-end.

Here's an example of how to use this in a real package: https://github.com/astropy/astropy-healpix/pull/59/files#diff-bcb5fcaf7fc1e3ab2ea2217cc624efc2

@bwinkel @wkerzendorf @cmccully - since you use -fopenmp in your packages (pycraf, tardis and astroscrappy respectively), I just thought you might be interested in this.