### PR TITLE
Don't install graphviz on CI services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ os:
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
-# The apt packages below are needed for sphinx builds, which can no longer
-# be installed with sudo apt-get.
-addons:
-    apt:
-        packages:
-            - graphviz
-
 env:
   matrix:
     - PYTHON_VERSION=2.7 EVENT_TYPE='push pull_request cron'
@@ -46,9 +39,6 @@ matrix:
       env: PYTHON_VERSION=3.5 SPHINX_VERSION='<1.5'
     - os: linux
       env: PYTHON_VERSION=3.6 SPHINX_VERSION='<1.6'
-
-before_install:
-    - if [[ $TRAVIS_OS_NAME == osx ]]; then brew update; brew install graphviz; fi
 
 install:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,9 +36,6 @@ install:
     - git config --global user.name "A U Thor"
     - git config --global user.email "author@example.com"
 
-    # Install graphviz
-    - cinst graphviz.portable
-
 # Not a .NET project, we build the package in the install step instead
 build: false
 

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -308,7 +308,7 @@ def test_build_docs(tmpdir, mode):
             from astropy_helpers.sphinx.conf import *
         exclude_patterns.append('_templates')
     """))
-    
+
     if mode == 'cli-error':
         docs_dir.join('conf.py').write(dedent("""
         raise ValueError("TestException")
@@ -316,6 +316,7 @@ def test_build_docs(tmpdir, mode):
 
     docs_dir.join('index.rst').write(dedent("""\
         .. automodapi:: mypackage
+           :no-inheritance-diagram:
     """))
 
     test_pkg.join('setup.py').write(dedent("""\


### PR DESCRIPTION
I **think** graphviz isn't needed anymore as this was needed for the automodapi tests which are now in the sphinx-automodapi repo. This will speed up the CI a fair bit especially on Mac.