### PR TITLE
Simplifying travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
 
   global:
     - CONDA_DEPENDENCIES="setuptools sphinx cython numpy"
-    - PIP_DEPENDENCIES="coveralls pytest-cov"
     - EVENT_TYPE='push pull_request'
 
 matrix:
@@ -37,7 +36,7 @@ matrix:
       env: PYTHON_VERSION=3.6 SPHINX_VERSION='>1.6'
 
     - os: linux
-      env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx coveralls pytest-cov'
+      env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx"
            CONDA_DEPENDENCIES="setuptools cython numpy"
 
     - os: linux


### PR DESCRIPTION
as ``ci-helpers`` takes care of installing pytest-cov and coveralls

(pending merging https://github.com/astropy/ci-helpers/pull/247)