### PR TITLE
Minor PEP8 fixes

### DIFF
--- a/astropy_helpers/git_helpers.py
+++ b/astropy_helpers/git_helpers.py
@@ -160,7 +160,7 @@ def get_git_devstr(sha=False, show_warning=True, path=None):
 
 # This function is tested but it is only ever executed within a subprocess when
 # creating a fake package, so it doesn't get picked up by coverage metrics.
-def _get_repo_path(pathname, levels=None): # pragma: no cover
+def _get_repo_path(pathname, levels=None):  # pragma: no cover
     """
     Given a file or directory name, determine the root of the git repository
     this path is under.  If given, this won't look any higher than ``levels``

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -116,6 +116,7 @@ except ImportError:
 _FROZEN_VERSION_PY_WITH_GIT_HEADER = """
 {git_helpers}
 
+
 _packagename = "{packagename}"
 _last_generated_version = "{verstr}"
 _last_githash = "{githash}"


### PR DESCRIPTION
The extra blank line before `_packagename` is necessary to separate the functions defined in `{git_helpers}` with two blank lines (e.g. see an autogenerated `version.py` file).