### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
       EVENT_TYPE='push pull_request cron'
 
   global:
+    - SETUPTOOLS_VERSION=27
     - CONDA_DEPENDENCIES="setuptools sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
     - EVENT_TYPE='push pull_request'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
       # babel 2.0 is known to break on Windows:
       # https://github.com/python-babel/babel/issues/174
-      CONDA_DEPENDENCIES: "numpy Cython sphinx pytest babel!=2.0"
+      CONDA_DEPENDENCIES: "numpy Cython sphinx pytest babel!=2.0 setuptools=27"
 
   matrix:
       - PYTHON_VERSION: "3.5"

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Topic :: System :: Archiving :: Packaging'
     ],
     cmdclass=cmdclass,
+    python_requires='>=3.5',
     zip_safe=False,
     **get_package_info(exclude=['astropy_helpers.tests'])
 )


### PR DESCRIPTION
Just in case anyone tries to pip install astropy-helpers, we should declare what Python versions it works with using ``python_requires``