### PR TITLE
Fix fetching of astropy-helpers on Python 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ astropy-helpers Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make sure that astropy-helpers 3.x.x is not downloaded on Python 2. [#362, #363]
 
 
 2.0.2 (2017-10-13)

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -139,6 +139,7 @@ from distutils.debug import DEBUG
 # TODO: Maybe enable checking for a specific version of astropy_helpers?
 DIST_NAME = 'astropy-helpers'
 PACKAGE_NAME = 'astropy_helpers'
+UPPER_VERSION_EXCLUSIVE = None
 
 # Defaults for other options
 DOWNLOAD_IF_NEEDED = True
@@ -494,7 +495,10 @@ class _Bootstrapper(object):
         if version:
             req = '{0}=={1}'.format(DIST_NAME, version)
         else:
-            req = DIST_NAME
+            if UPPER_VERSION_EXCLUSIVE is None:
+                req = DIST_NAME
+            else:
+                req = '{0}<{1}'.format(DIST_NAME, UPPER_VERSION_EXCLUSIVE)
 
         attrs = {'setup_requires': [req]}
 


### PR DESCRIPTION
As reported on https://github.com/astropy/astropy-helpers/issues/359 - the issue is that if the astropy-helpers submodule is not present or not checked out on Python 2, ``ah_bootstrap.py`` will then fetch the absolute latest version of astropy-helpers. This PR introduces a strict upper limit to the versions that will be fetched.

I considered another solution that would re-use ``_do_upgrade`` to only get the latest bugfix release, but when the submodule is not checked out, ``ah_bootstrap.py`` is not really tied to a specific astropy-helpers version - in fact maybe the reason some people don't include the submodule is precisely to not have to update astropy-helpers as often. So I think the fix in this PR is the right way to go.

This should be backported to v2.0.x - by the way this does raise the question of how we will update the astropy-helpers in different repos with these releases - how do we know whether to use the latest v2.0.x release or the v3.0.0 release? (maybe we can do some heuristics based on ``setup.py`` and e.g. ``.travis.yml``?)