### PR TITLE
Fix fetching of astropy-helpers on Python 2 [v2.0.x]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
       EVENT_TYPE='push pull_request cron'
 
   global:
+    - SETUPTOOLS_VERSION=27
     - CONDA_DEPENDENCIES="setuptools sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
     - EVENT_TYPE='push pull_request'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ astropy-helpers Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make sure that astropy-helpers 3.x.x is not downloaded on Python 2. [#363]
 
 
 2.0.2 (2017-10-13)

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -147,6 +147,11 @@ from distutils.debug import DEBUG
 DIST_NAME = 'astropy-helpers'
 PACKAGE_NAME = 'astropy_helpers'
 
+if PY3:
+    UPPER_VERSION_EXCLUSIVE = None
+else:
+    UPPER_VERSION_EXCLUSIVE = '3'
+
 # Defaults for other options
 DOWNLOAD_IF_NEEDED = True
 INDEX_URL = 'https://pypi.python.org/simple'
@@ -501,7 +506,10 @@ class _Bootstrapper(object):
         if version:
             req = '{0}=={1}'.format(DIST_NAME, version)
         else:
-            req = DIST_NAME
+            if UPPER_VERSION_EXCLUSIVE is None:
+                req = DIST_NAME
+            else:
+                req = '{0}<{1}'.format(DIST_NAME, UPPER_VERSION_EXCLUSIVE)
 
         attrs = {'setup_requires': [req]}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
       # babel 2.0 is known to break on Windows:
       # https://github.com/python-babel/babel/issues/174
-      CONDA_DEPENDENCIES: "numpy Cython sphinx pytest babel!=2.0"
+      CONDA_DEPENDENCIES: "numpy Cython sphinx pytest babel!=2.0 setuptools=27"
 
   matrix:
       - PYTHON_VERSION: "2.7"


### PR DESCRIPTION
This is a version specific to the v2.0.x branch