### PR TITLE
Add command-line flags to control usage of system installation of astropy-helpers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ astropy-helpers Changelog
 - Removing unused 'register' command since packages should be uploaded
   with twine and get registered automatically. [#332]
 
+- Add --auto-use and --no-auto-use command-line flags to match the
+  ``auto_use`` configuration option, and add an alias
+  ``--use-system-astropy-helpers`` for ``--no-auto-use``.
 
 2.0.3 (unreleased)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ astropy-helpers Changelog
 
 - Add --auto-use and --no-auto-use command-line flags to match the
   ``auto_use`` configuration option, and add an alias
-  ``--use-system-astropy-helpers`` for ``--no-auto-use``.
+  ``--use-system-astropy-helpers`` for ``--no-auto-use``. [#366]
 
 2.0.3 (unreleased)
 ------------------

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -19,9 +19,14 @@ that section, and options therein, determine the next step taken:  If it
 contains an option called ``auto_use`` with a value of ``True``, it will
 automatically call the main function of this module called
 `use_astropy_helpers` (see that function's docstring for full details).
-Otherwise no further action is taken (however,
-``ah_bootstrap.use_astropy_helpers`` may be called manually from within the
-setup.py script).
+Otherwise no further action is taken and by default the system-installed version
+of astropy-helpers will be used (however, ``ah_bootstrap.use_astropy_helpers``
+may be called manually from within the setup.py script).
+
+This behavior can also be controlled using the ``--auto-use`` and
+``--no-auto-use`` command-line flags. For clarity, an alias for
+``--no-auto-use`` is ``--use-system-astropy-helpers``, and we recommend using
+the latter if needed.
 
 Additional options in the ``[ah_boostrap]`` section of setup.cfg have the same
 names as the arguments to `use_astropy_helpers`, and can be used to configure
@@ -280,6 +285,18 @@ class _Bootstrapper(object):
         if '--offline' in argv:
             config['offline'] = True
             argv.remove('--offline')
+
+        if '--auto-use' in argv:
+            config['auto_use'] = True
+            argv.remove('--auto-use')
+
+        if '--no-auto-use' in argv:
+            config['auto_use'] = False
+            argv.remove('--no-auto-use')
+
+        if '--use-system-astropy-helpers' in argv:
+            config['auto_use'] = False
+            argv.remove('--use-system-astropy-helpers')
 
         return config
 


### PR DESCRIPTION
@bsipocz - I added a changelog entry in 3.0 but if it's too late for RC2 we can just include in 3.1. What do you think?

Fixes https://github.com/astropy/astropy-helpers/issues/350