### PR TITLE
Support dotted package names as namespace packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,8 @@ astropy-helpers Changelog
 2.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support dotted package names as namespace packages in generate_version_py.
+  [#370]
 
 
 2.0.3 (2018-01-20)

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -245,7 +245,8 @@ def generate_version_py(packagename, version, release=None, debug=None,
         # Likewise, keep whatever the current value is, if it exists
         debug = bool(current_debug)
 
-    version_py = os.path.join(srcdir, packagename, 'version.py')
+    package_srcdir = os.path.join(srcdir, *packagename.split('.'))
+    version_py = os.path.join(package_srcdir, 'version.py')
 
     if (last_generated_version != version or current_release != release or
             current_debug != debug):


### PR DESCRIPTION
I am making a new project using the Astropy affiliated package where the root of the package lives inside another namespace package. For concreteness, the package is called [`ligo.skymap` or `ligo-skymap`](http://git.ligo.org/leo-singer/ligo.skymap), the top-level package is called `ligo.skymap`, and it lives inside a namespace shared by a number of other packages [`ligo.lvalert`](https://git.ligo.org/lscsoft/lvalert), [`ligo.gracedb`](https://git.ligo.org/lscsoft/gracedb-client).

However, this does not work with astropy_helpers because the function `generate_version_py` in astropy_helpers expects that the package name to be the same as the directory containing `version.py`.

This patch allows the package name to contain dots, which are interpreted as the fully-qualified name of a module. The dots are translated to path separators before writing the `version.py` script.