### PR TITLE
Fix compatibility with the latest versions of setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
       EVENT_TYPE='push pull_request cron'
 
   global:
-    - SETUPTOOLS_VERSION=27
     - CONDA_DEPENDENCIES="setuptools sphinx cython numpy"
     - PIP_DEPENDENCIES="coveralls pytest-cov"
     - EVENT_TYPE='push pull_request'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ matrix:
     - os: linux
       env: PYTHON_VERSION=3.5 SPHINX_VERSION='<1.4'
     - os: linux
-      env: PYTHON_VERSION=3.5 SPHINX_VERSION='<1.5'
+      env: PYTHON_VERSION=3.5 SPHINX_VERSION='<1.5' SETUPTOOLS_VERSION=27
     - os: linux
-      env: PYTHON_VERSION=3.6 SPHINX_VERSION='<1.6'
+      env: PYTHON_VERSION=3.6 SPHINX_VERSION='<1.6' SETUPTOOLS_VERSION=27
 
   allow_failures:
     - env: PYTHON_VERSION=3.6 SETUPTOOLS_VERSION=dev DEBUG=True

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ astropy-helpers Changelog
 3.0 (unreleased)
 ----------------
 
+- Fix compatibility with the latest version of setuptools. [#372]
+
 - Removing Python 2 support, including 2to3. Packages wishing to keep Python
   2 support should NOT update to this version. [#340]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,6 @@ astropy-helpers Changelog
 3.0 (unreleased)
 ----------------
 
-- Fix compatibility with the latest version of setuptools. [#372]
-
 - Removing Python 2 support, including 2to3. Packages wishing to keep Python
   2 support should NOT update to this version. [#340]
 
@@ -20,12 +18,13 @@ astropy-helpers Changelog
 - Removing unused 'register' command since packages should be uploaded
   with twine and get registered automatically. [#332]
 
-
 2.0.4 (unreleased)
 ------------------
 
 - Support dotted package names as namespace packages in generate_version_py.
   [#370]
+
+- Fix compatibility with setuptools 36.x and above. [#372]
 
 
 2.0.3 (2018-01-20)

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -519,12 +519,22 @@ class _Bootstrapper(object):
 
         attrs = {'setup_requires': [req]}
 
+        # NOTE: we need to parse the config file (e.g. setup.cfg) to make sure
+        # it honours the options set in the [easy_install] section, and we need
+        # to explicitly fetch the requirement eggs as setup_requires does not
+        # get honored in recent versions of setuptools:
+        # https://github.com/pypa/setuptools/issues/1273
+
         try:
             if DEBUG:
-                _Distribution(attrs=attrs)
+                dist = _Distribution(attrs=attrs)
+                dist.parse_config_files(ignore_option_errors=True)
+                dist.fetch_build_eggs(req)
             else:
                 with _silence():
-                    _Distribution(attrs=attrs)
+                    dist = _Distribution(attrs=attrs)
+                    dist.parse_config_files(ignore_option_errors=True)
+                    dist.fetch_build_eggs(req)
 
             # If the setup_requires succeeded it will have added the new dist to
             # the main working_set

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
       # babel 2.0 is known to break on Windows:
       # https://github.com/python-babel/babel/issues/174
-      CONDA_DEPENDENCIES: "numpy Cython sphinx pytest babel!=2.0 setuptools=27"
+      CONDA_DEPENDENCIES: "numpy Cython sphinx pytest babel!=2.0 setuptools"
 
   matrix:
       - PYTHON_VERSION: "3.5"


### PR DESCRIPTION
The first change is to call fetch_build_eggs explicitly as in recent versions of setuptools the setup_requires does not appear to be respected. The second change is to explicitly parse the setup.cfg file as this appears to not be done inside Distribution anymore but at a higher level.

Fixes https://github.com/astropy/astropy-helpers/issues/361