### PR TITLE
Only link object files in add_openmp_flags_if_available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ astropy-helpers Changelog
 
 - Fix compatibility with setuptools 36.x and above. [#372]
 
+- Fix false negative in add_openmp_flags_if_available when measuring code
+  coverage with gcc. [#374]
 
 2.0.3 (2018-01-20)
 ------------------

--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -73,7 +73,7 @@ def add_openmp_flags_if_available(extension):
 
         # Compile, link, and run test program
         ccompiler.compile(['test_openmp.c'], output_dir='objects', extra_postargs=[compile_flag])
-        ccompiler.link_executable(glob.glob(os.path.join('objects', '*')), 'test_openmp', extra_postargs=[link_flag])
+        ccompiler.link_executable(glob.glob(os.path.join('objects', '*' + ccompiler.obj_extension)), 'test_openmp', extra_postargs=[link_flag])
         output = subprocess.check_output('./test_openmp').decode(sys.stdout.encoding or 'utf-8').splitlines()
 
         if 'nthreads=' in output[0]:


### PR DESCRIPTION
Restrict the OpenMP test to attempting to link files that end in the compiler's object file extension as determined by `ccompiler.obj_extension`.

The OpenMP test was yielding a false negative if the user had set the environment variable `CFLAGS='-coverage'` to measure code coverage with GCC. The error message was:

    /usr/bin/ld:objects/test_openmp.gcno: file format not recognized; treating as linker script
    /usr/bin/ld:objects/test_openmp.gcno:1: syntax error

When GCC is called with the `-coverage` option, it emits extra data files, which should *not* be passed to the linker because they are not object files.