### PR TITLE
Fix segmentation faults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ before_script:
 script:
     # Use full path for coveragerc; see issue #193
     - py.test --cov astropy_helpers --cov-config $(pwd)/astropy_helpers/tests/coveragerc astropy_helpers
+    - mv .coverage .coverage.main
+    - coverage combine .coverage.main .coverage.subprocess
 
 after_success:
     - coveralls --rcfile=astropy_helpers/tests/coveragerc

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,12 @@ before_script:
 script:
     # Use full path for coveragerc; see issue #193
     - py.test --cov astropy_helpers --cov-config $(pwd)/astropy_helpers/tests/coveragerc astropy_helpers
+
+    # In conftest.py we produce a .coverage.subprocess that contains coverage
+    # statistics for sub-processes, so we combine it with the main one here.
     - mv .coverage .coverage.main
     - coverage combine .coverage.main .coverage.subprocess
+    - coverage report
 
 after_success:
     - coveralls --rcfile=astropy_helpers/tests/coveragerc

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ matrix:
     - env: PYTHON_VERSION=3.6 SETUPTOOLS_VERSION=dev DEBUG=True
            CONDA_DEPENDENCIES='sphinx cython numpy packaging appdirs'
            EVENT_TYPE='push pull_request cron'
-
+    - env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx coveralls pytest-cov'
+           CONDA_DEPENDENCIES="setuptools cython numpy"
 install:
 
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   matrix:
     - PYTHON_VERSION=3.5
     - PYTHON_VERSION=3.6 SETUPTOOLS_VERSION=dev DEBUG=True
-      CONDA_DEPENDENCIES='sphinx cython numpy packaging appdirs'
+      CONDA_DEPENDENCIES='sphinx cython numpy pytest-cov'
       EVENT_TYPE='push pull_request cron'
 
   global:
@@ -37,10 +37,8 @@ matrix:
            CONDA_DEPENDENCIES="setuptools cython numpy pytest-cov"
   allow_failures:
     - env: PYTHON_VERSION=3.6 SETUPTOOLS_VERSION=dev DEBUG=True
-           CONDA_DEPENDENCIES='sphinx cython numpy packaging appdirs'
+           CONDA_DEPENDENCIES='sphinx cython numpy pytest-cov'
            EVENT_TYPE='push pull_request cron'
-    - env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx coveralls pytest-cov'
-           CONDA_DEPENDENCIES="setuptools cython numpy"
 install:
 
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,16 @@ matrix:
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx coveralls'
            CONDA_DEPENDENCIES="setuptools cython numpy pytest-cov"
-  allow_failures:
-    - env: PYTHON_VERSION=3.6 SETUPTOOLS_VERSION=dev DEBUG=True
-           CONDA_DEPENDENCIES='sphinx cython numpy pytest-cov'
-           EVENT_TYPE='push pull_request cron'
+
+  # Uncomment the following if there are issues in setuptools that we
+  # can't work around quickly - otherwise leave uncommented so that
+  # we notice when things go wrong.
+  #
+  # allow_failures:
+  #   - env: PYTHON_VERSION=3.6 SETUPTOOLS_VERSION=dev DEBUG=True
+  #          CONDA_DEPENDENCIES='sphinx cython numpy pytest-cov'
+  #          EVENT_TYPE='push pull_request cron'
+
 install:
 
     - git clone git://github.com/astropy/ci-helpers.git

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,8 +34,7 @@ astropy-helpers Changelog
 ------------------
 
 - Fix segmentation faults that occurred when the astropy-helpers submodule
-  was first initialized and packages using astropy-helpers contained
-  Cython code. [#375]
+  was first initialized in packages that also contained Cython code. [#375]
 
 2.0.4 (2018-02-09)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,8 +33,9 @@ astropy-helpers Changelog
 2.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix segmentation faults that occurred when the astropy-helpers submodule
+  was first initialized and packages using astropy-helpers contained
+  Cython code. [#375]
 
 2.0.4 (2018-02-09)
 ------------------

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -135,7 +135,6 @@ import pkg_resources
 
 from setuptools import Distribution
 from setuptools.package_index import PackageIndex
-from setuptools.sandbox import run_setup
 
 from distutils import log
 from distutils.debug import DEBUG
@@ -475,9 +474,10 @@ class _Bootstrapper(object):
             # setup.py exists we can generate it
             setup_py = os.path.join(path, 'setup.py')
             if os.path.isfile(setup_py):
-                with _silence():
-                    run_setup(os.path.join(path, 'setup.py'),
-                              ['egg_info'])
+                # We use subprocess instead of run_setup from setuptools to
+                # avoid segmentation faults - see the following for more details:
+                # https://github.com/cython/cython/issues/2104
+                sp.check_output([sys.executable, 'setup.py', 'egg_info'], cwd=path)
 
                 for dist in pkg_resources.find_distributions(path, True):
                     # There should be only one...

--- a/astropy_helpers/conftest.py
+++ b/astropy_helpers/conftest.py
@@ -1,0 +1,55 @@
+import os
+import glob
+
+try:
+    from coverage import CoverageData
+except ImportError:
+    HAS_COVERAGE = False
+else:
+    HAS_COVERAGE = True
+
+# Since we run many of the tests in sub-processes, we need to collect coverage
+# data inside each subprocess and then combine it into a single .coverage file.
+# To do this we set up a list which run_setup appends coverage objects to.
+
+if HAS_COVERAGE:
+    SUBPROCESS_COVERAGE = []
+
+
+def pytest_configure(config):
+    if HAS_COVERAGE:
+        SUBPROCESS_COVERAGE.clear()
+
+
+def pytest_unconfigure(config):
+
+    if HAS_COVERAGE:
+
+        # We create an empty coverage data object
+        combined_cdata = CoverageData()
+
+        # Add all files from astropy_helpers to make sure we compute the total
+        # coverage, not just the coverage of the files that have non-zero
+        # coverage.
+
+        lines = {}
+        for filename in glob.glob(os.path.join('astropy_helpers', '**', '*.py'), recursive=True):
+            lines[os.path.abspath(filename)] = []
+
+        for cdata in SUBPROCESS_COVERAGE:
+            # For each CoverageData object, we go through all the files and
+            # change the filename from one which might be a temporary path
+            # to the local filename. We then only keep files that actually
+            # exist.
+            for filename in cdata.measured_files():
+                try:
+                    pos = filename.rindex('astropy_helpers')
+                except ValueError:
+                    continue
+                short_filename = filename[pos:]
+                if os.path.exists(short_filename):
+                    lines[os.path.abspath(short_filename)].extend(cdata.lines(filename))
+
+        combined_cdata.add_lines(lines)
+
+        combined_cdata.write_file('.coverage.subprocess')

--- a/astropy_helpers/conftest.py
+++ b/astropy_helpers/conftest.py
@@ -1,3 +1,9 @@
+# This file contains settings for pytest that are specific to astropy-helpers.
+# Since we run many of the tests in sub-processes, we need to collect coverage
+# data inside each subprocess and then combine it into a single .coverage file.
+# To do this we set up a list which run_setup appends coverage objects to.
+# This is not intended to be used by packages other than astropy-helpers.
+
 import os
 import glob
 
@@ -7,10 +13,6 @@ except ImportError:
     HAS_COVERAGE = False
 else:
     HAS_COVERAGE = True
-
-# Since we run many of the tests in sub-processes, we need to collect coverage
-# data inside each subprocess and then combine it into a single .coverage file.
-# To do this we set up a list which run_setup appends coverage objects to.
 
 if HAS_COVERAGE:
     SUBPROCESS_COVERAGE = []

--- a/astropy_helpers/tests/__init__.py
+++ b/astropy_helpers/tests/__init__.py
@@ -2,8 +2,6 @@ import os
 import subprocess as sp
 import sys
 
-from setuptools import sandbox
-
 import pytest
 
 from ..utils import extends_doc
@@ -39,7 +37,6 @@ def run_cmd(cmd, args, path=None, raise_error=True):
     return streams + (return_code,)
 
 
-@extends_doc(sandbox.run_setup)
 def run_setup(setup_script, args):
 
     # This used to call setuptools.sandbox's run_setup, but due to issues with
@@ -52,19 +49,12 @@ def run_setup(setup_script, args):
     if not path:
         path = None
 
-    import subprocess
-    p = subprocess.Popen([sys.executable, setup_script] + list(args), cwd=path,
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = sp.Popen([sys.executable, setup_script] + list(args), cwd=path,
+                 stdout=sp.PIPE, stderr=sp.PIPE)
     stdout, stderr = p.communicate()
 
     sys.stdout.write(stdout.decode('utf-8'))
     sys.stderr.write(stderr.decode('utf-8'))
-
-    # try:
-    #     return sandbox.run_setup(*args, **kwargs)
-    # finally:
-    #     import importlib
-    #     importlib.invalidate_caches()
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -96,23 +86,6 @@ def reset_distutils_log():
 
     from distutils import log
     log.set_threshold(log.WARN)
-
-
-@pytest.fixture(scope='module', autouse=True)
-def fix_hide_setuptools():
-    """
-    Workaround for https://github.com/astropy/astropy-helpers/issues/124
-
-    In setuptools 10.0 run_setup was changed in such a way that it sweeps
-    away the existing setuptools import before running the setup script.  In
-    principle this is nice, but in the practice of testing astropy_helpers
-    this is problematic since we're trying to test code that has already been
-    imported during the testing process, and which relies on the setuptools
-    module that was already in use.
-    """
-
-    if hasattr(sandbox, 'hide_setuptools'):
-        sandbox.hide_setuptools = lambda: None
 
 
 TEST_PACKAGE_SETUP_PY = """\

--- a/astropy_helpers/tests/coveragerc
+++ b/astropy_helpers/tests/coveragerc
@@ -7,6 +7,7 @@ omit =
    astropy_helpers/extern/*
    astropy_helpers/extern/*/*
    astropy_helpers/tests/*
+   astropy_helpers/conftest.py
    */test_pkg/*
 
 [report]

--- a/astropy_helpers/tests/test_ah_bootstrap.py
+++ b/astropy_helpers/tests/test_ah_bootstrap.py
@@ -11,7 +11,7 @@ import setuptools
 
 import pytest
 
-from . import reset_setup_helpers, reset_distutils_log, fix_hide_setuptools  # noqa
+from . import reset_setup_helpers, reset_distutils_log  # noqa
 from . import run_cmd, run_setup, testpackage
 from ..utils import silence
 
@@ -22,9 +22,11 @@ from __future__ import print_function
 
 import os
 import sys
-from copy import copy
 
-args = copy(sys.argv)
+# This import is not the real run of ah_bootstrap for the purposes of the test,
+# so we need to preserve the command-line arguments otherwise these get eaten
+# up by this import
+args = sys.argv[:]
 import ah_bootstrap
 sys.argv = args
 
@@ -56,6 +58,8 @@ assert '--no-git' not in sys.argv
 import _astropy_helpers_test_
 filename = os.path.abspath(_astropy_helpers_test_.__file__)
 filename = filename.replace('.pyc', '.py')  # More consistent this way
+
+# We print out variables that are needed in tests below in JSON
 import json
 data = {{}}
 data['filename'] = filename
@@ -206,9 +210,6 @@ def test_check_submodule_no_git(capsys, tmpdir, testpackage):
         run_setup('setup.py', ['--no-git'])
 
         stdout, stderr = capsys.readouterr()
-
-        print(stdout)
-        print(stderr)
 
         use_git = bool(json.loads(stdout.strip())['ah_bootstrap.BOOTSTRAPPER.use_git'])
 
@@ -416,8 +417,6 @@ def test_upgrade(tmpdir, capsys):
         run_setup('setup.py', [])
 
         stdout, stderr = capsys.readouterr()
-        print(stdout)
-        print(stderr)
         path = json.loads(stdout.strip())['filename']
         eggs = _get_local_eggs()
         assert eggs

--- a/astropy_helpers/tests/test_ah_bootstrap.py
+++ b/astropy_helpers/tests/test_ah_bootstrap.py
@@ -97,9 +97,10 @@ def test_bootstrap_from_submodule(tmpdir, testpackage, capsys):
 
     with orig_repo.as_cwd():
 
-        orig_repo.join('ah_bootstrap.py').write(AH_BOOTSTRAP)
-
         run_cmd('git', ['init'])
+
+        orig_repo.join('ah_bootstrap.py').write(AH_BOOTSTRAP)
+        run_cmd('git', ['add', 'ah_bootstrap.py'])
 
         # Write a test setup.py that uses ah_bootstrap; it also ensures that
         # any previous reference to astropy_helpers is first wiped from

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -15,7 +15,7 @@ from astropy_helpers.git_helpers import get_git_devstr
 
 _DEV_VERSION_RE = re.compile(r'\d+\.\d+(?:\.\d+)?\.dev(\d+)')
 
-ASTROPY_HELPERS_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+ASTROPY_HELPERS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 TEST_VERSION_SETUP_PY = """\
 #!/usr/bin/env python
@@ -27,7 +27,7 @@ NAME = 'apyhtest_eva'
 VERSION = {version!r}
 RELEASE = 'dev' not in VERSION
 
-sys.path.insert(0, '{astropy_helpers_path}')
+sys.path.insert(0, r'{astropy_helpers_path}')
 
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -15,14 +15,19 @@ from astropy_helpers.git_helpers import get_git_devstr
 
 _DEV_VERSION_RE = re.compile(r'\d+\.\d+(?:\.\d+)?\.dev(\d+)')
 
+ASTROPY_HELPERS_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+
 TEST_VERSION_SETUP_PY = """\
 #!/usr/bin/env python
 
+import sys
 from setuptools import setup
 
 NAME = 'apyhtest_eva'
 VERSION = {version!r}
 RELEASE = 'dev' not in VERSION
+
+sys.path.insert(0, '{astropy_helpers_path}')
 
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
@@ -50,7 +55,8 @@ def version_test_package(tmpdir, request):
     def make_test_package(version='42.42.dev'):
         test_package = tmpdir.mkdir('test_package')
         test_package.join('setup.py').write(
-            TEST_VERSION_SETUP_PY.format(version=version))
+            TEST_VERSION_SETUP_PY.format(version=version,
+                                         astropy_helpers_path=ASTROPY_HELPERS_PATH))
         test_package.mkdir('apyhtest_eva').join('__init__.py').write(TEST_VERSION_INIT)
         with test_package.as_cwd():
             run_cmd('git', ['init'])

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -9,7 +9,7 @@ import tarfile
 import pytest
 from warnings import catch_warnings
 
-from . import reset_setup_helpers, reset_distutils_log, fix_hide_setuptools  # noqa
+from . import reset_setup_helpers, reset_distutils_log  # noqa
 from . import run_cmd, run_setup, cleanup_import
 from astropy_helpers.git_helpers import get_git_devstr
 

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -2,7 +2,6 @@ import os
 import sys
 import stat
 import shutil
-import warnings
 import contextlib
 
 import pytest
@@ -13,9 +12,8 @@ from setuptools import Distribution
 
 from ..setup_helpers import get_package_info, register_commands
 from ..commands import build_ext
-from ..utils import AstropyDeprecationWarning
 
-from . import reset_setup_helpers, reset_distutils_log, fix_hide_setuptools  # noqa
+from . import reset_setup_helpers, reset_distutils_log  # noqa
 from . import run_setup, cleanup_import
 
 
@@ -242,10 +240,6 @@ def test_missing_cython_c_files(capsys, pyx_extension_test_package, monkeypatch)
         run_setup('setup.py', ['build_ext', '--inplace', '--no-cython'])
 
         stdout, stderr = capsys.readouterr()
-
-        print(stdout)
-        print(stderr)
-
         assert "No git repository present at" in stderr
 
         msg = ('Could not find C/C++ file '

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -16,7 +16,7 @@ from ..commands import build_ext
 from . import reset_setup_helpers, reset_distutils_log  # noqa
 from . import run_setup, cleanup_import
 
-ASTROPY_HELPERS_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+ASTROPY_HELPERS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 
 def _extension_test_package(tmpdir, request, extension_type='c'):
@@ -89,7 +89,7 @@ def _extension_test_package(tmpdir, request, extension_type='c'):
         import sys
         from os.path import join
         from setuptools import setup
-        sys.path.insert(0, '{astropy_helpers_path}')
+        sys.path.insert(0, r'{astropy_helpers_path}')
         from astropy_helpers.setup_helpers import register_commands
         from astropy_helpers.setup_helpers import get_package_info
         from astropy_helpers.version_helpers import generate_version_py
@@ -300,7 +300,7 @@ def test_build_docs(capsys, tmpdir, mode):
 
     test_pkg.join('setup.py').write(dedent("""\
         import sys
-        sys.path.insert(0, '{astropy_helpers_path}')
+        sys.path.insert(0, r'{astropy_helpers_path}')
         from os.path import join
         from setuptools import setup, Extension
         from astropy_helpers.setup_helpers import register_commands, get_package_info
@@ -356,7 +356,7 @@ def test_command_hooks(tmpdir, capsys):
         import sys
         from os.path import join
         from setuptools import setup, Extension
-        sys.path.insert(0, '{astropy_helpers_path}')
+        sys.path.insert(0, r'{astropy_helpers_path}')
         from astropy_helpers.setup_helpers import register_commands, get_package_info
 
         NAME = '_welltall_'
@@ -528,7 +528,7 @@ def test_invalid_package_exclusion(tmpdir, capsys):
         import sys
         from os.path import join
         from setuptools import setup, Extension
-        sys.path.insert(0, '{astropy_helpers_path}')
+        sys.path.insert(0, r'{astropy_helpers_path}')
         from astropy_helpers.setup_helpers import register_commands, \\
             get_package_info, add_exclude_packages
 

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -86,11 +86,17 @@ def _extension_test_package(tmpdir, request, extension_type='c'):
     """.format(', '.join(extensions_list))))
 
     test_pkg.join('setup.py').write(dedent("""\
+        import sys
         from os.path import join
         from setuptools import setup
         from astropy_helpers.setup_helpers import register_commands
         from astropy_helpers.setup_helpers import get_package_info
         from astropy_helpers.version_helpers import generate_version_py
+
+        if '--no-cython' in sys.argv:
+            from astropy_helpers.commands import build_ext
+            build_ext.should_build_with_cython = lambda *args: False
+            sys.argv.remove('--no-cython')
 
         NAME = 'apyhtest_eva'
         VERSION = '0.1'
@@ -160,7 +166,7 @@ def test_cython_autoextensions(tmpdir):
     assert package_info['ext_modules'][0].name == 'yoda.luke.dagobah'
 
 
-def test_compiler_module(c_extension_test_package):
+def test_compiler_module(capsys, c_extension_test_package):
     """
     Test ensuring that the compiler module is built and installed for packages
     that have extension modules.
@@ -172,16 +178,14 @@ def test_compiler_module(c_extension_test_package):
     with test_pkg.as_cwd():
         # This is one of the simplest ways to install just a package into a
         # test directory
-        with warnings.catch_warnings(record=True) as w:
-            run_setup('setup.py',
-                      ['install',
-                       '--single-version-externally-managed',
-                       '--install-lib={0}'.format(install_temp),
-                       '--record={0}'.format(install_temp.join('record.txt'))])
+        run_setup('setup.py',
+                  ['install',
+                   '--single-version-externally-managed',
+                   '--install-lib={0}'.format(install_temp),
+                   '--record={0}'.format(install_temp.join('record.txt'))])
 
-        # Warning expected from get_git_devstr, called by generate_version_py
-        assert len(w) == 1
-        assert str(w[0].message).startswith("No git repository present at")
+        stdout, stderr = capsys.readouterr()
+        assert "No git repository present at" in stderr
 
     with install_temp.as_cwd():
         import apyhtest_eva
@@ -195,7 +199,7 @@ def test_compiler_module(c_extension_test_package):
         assert apyhtest_eva.version.compiler != 'unknown'
 
 
-def test_no_cython_buildext(c_extension_test_package, monkeypatch):
+def test_no_cython_buildext(capsys, c_extension_test_package, monkeypatch):
     """
     Regression test for https://github.com/astropy/astropy-helpers/pull/35
 
@@ -206,17 +210,12 @@ def test_no_cython_buildext(c_extension_test_package, monkeypatch):
 
     test_pkg = c_extension_test_package
 
-    # In order for this test to test the correct code path we need to fool
-    # build_ext into thinking we don't have Cython installed
-    monkeypatch.setattr(build_ext, 'should_build_with_cython',
-                        lambda *args: False)
-
     with test_pkg.as_cwd():
-        with warnings.catch_warnings(record=True) as w:
-            run_setup('setup.py', ['build_ext', '--inplace'])
 
-        assert len(w) == 1
-        assert str(w[0].message).startswith("No git repository present at")
+        run_setup('setup.py', ['build_ext', '--inplace', '--no-cython'])
+
+        stdout, stderr = capsys.readouterr()
+        assert "No git repository present at" in stderr
 
     sys.path.insert(0, str(test_pkg))
 
@@ -228,7 +227,7 @@ def test_no_cython_buildext(c_extension_test_package, monkeypatch):
         sys.path.remove(str(test_pkg))
 
 
-def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
+def test_missing_cython_c_files(capsys, pyx_extension_test_package, monkeypatch):
     """
     Regression test for https://github.com/astropy/astropy-helpers/pull/181
 
@@ -238,24 +237,21 @@ def test_missing_cython_c_files(pyx_extension_test_package, monkeypatch):
 
     test_pkg = pyx_extension_test_package
 
-    # In order for this test to test the correct code path we need to fool
-    # build_ext into thinking we don't have Cython installed
-    monkeypatch.setattr(build_ext, 'should_build_with_cython',
-                        lambda *args: False)
-
     with test_pkg.as_cwd():
-        with pytest.raises(SystemExit) as exc_info:
-            with warnings.catch_warnings(record=True) as w:
-                run_setup('setup.py', ['build_ext', '--inplace'])
 
-            assert len(w) == 1
-            assert str(w[0].message).startswith(
-                "No git repository present at")
+        run_setup('setup.py', ['build_ext', '--inplace', '--no-cython'])
 
-    msg = ('Could not find C/C++ file '
-           '{0}.(c/cpp)'.format('apyhtest_eva/unit02'.replace('/', os.sep)))
+        stdout, stderr = capsys.readouterr()
 
-    assert msg in str(exc_info.value)
+        print(stdout)
+        print(stderr)
+
+        assert "No git repository present at" in stderr
+
+        msg = ('Could not find C/C++ file '
+               '{0}.(c/cpp)'.format('apyhtest_eva/unit02'.replace('/', os.sep)))
+
+        assert msg in stderr
 
 
 MODES = ['cli', 'cli-w', 'deprecated', 'cli-l', 'cli-error']
@@ -269,7 +265,7 @@ else:
 
 
 @pytest.mark.parametrize('mode', MODES)
-def test_build_docs(tmpdir, mode):
+def test_build_docs(capsys, tmpdir, mode):
     """
     Test for build_docs
     """
@@ -344,8 +340,9 @@ def test_build_docs(tmpdir, mode):
         elif mode == 'cli-l':
             run_setup('setup.py', ['build_docs', '-l'])
         elif mode == 'deprecated':
-            with pytest.warns(AstropyDeprecationWarning):
-                run_setup('setup.py', ['build_sphinx'])
+            run_setup('setup.py', ['build_sphinx'])
+            stdout, stderr = capsys.readouterr()
+            assert 'AstropyDeprecationWarning' in stderr
         elif mode == 'direct':  # to check coverage
             with docs_dir.as_cwd():
                 from sphinx import main
@@ -578,14 +575,13 @@ def test_invalid_package_exclusion(tmpdir, capsys):
         setup_header + error_commands + setup_footer)
 
     with error_pkg.as_cwd():
-        try:
-            with pytest.raises(RuntimeError):
-                run_setup('setup.py', ['build'])
-        finally:
-            cleanup_import(module_name)
+        run_setup('setup.py', ['build'])
+
+        stdout, stderr = capsys.readouterr()
+        assert "RuntimeError" in stderr
 
     # Test warning when using deprecated exclude parameter
-    warn_commands =  dedent("""\
+    warn_commands = dedent("""\
         cmdclassd = register_commands(NAME, VERSION, RELEASE)
         package_info = get_package_info(exclude=['test*'])
 
@@ -596,8 +592,6 @@ def test_invalid_package_exclusion(tmpdir, capsys):
         setup_header + warn_commands + setup_footer)
 
     with warn_pkg.as_cwd():
-        try:
-            with pytest.warns(AstropyDeprecationWarning):
-                run_setup('setup.py', ['build'])
-        finally:
-            cleanup_import(module_name)
+        run_setup('setup.py', ['build'])
+        stdout, stderr = capsys.readouterr()
+        assert 'AstropyDeprecationWarning' in stderr

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -387,7 +387,7 @@ def test_command_hooks(tmpdir, capsys):
         Goodbye build!
     """).strip()
 
-    assert want in stdout
+    assert want in stdout.replace('\r\n', '\n').replace('\r', '\n')
 
 
 def test_adjust_compiler(monkeypatch, tmpdir):

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -16,6 +16,8 @@ from ..commands import build_ext
 from . import reset_setup_helpers, reset_distutils_log  # noqa
 from . import run_setup, cleanup_import
 
+ASTROPY_HELPERS_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
+
 
 def _extension_test_package(tmpdir, request, extension_type='c'):
     """Creates a simple test package with an extension module."""
@@ -87,6 +89,7 @@ def _extension_test_package(tmpdir, request, extension_type='c'):
         import sys
         from os.path import join
         from setuptools import setup
+        sys.path.insert(0, '{astropy_helpers_path}')
         from astropy_helpers.setup_helpers import register_commands
         from astropy_helpers.setup_helpers import get_package_info
         from astropy_helpers.version_helpers import generate_version_py
@@ -110,7 +113,7 @@ def _extension_test_package(tmpdir, request, extension_type='c'):
             cmdclass=cmdclassd,
             **package_info
         )
-    """))
+    """.format(astropy_helpers_path=ASTROPY_HELPERS_PATH)))
 
     if '' in sys.path:
         sys.path.remove('')
@@ -366,8 +369,10 @@ def test_command_hooks(tmpdir, capsys):
     # A simple setup.py for the test package--running register_commands should
     # discover and enable the command hooks
     test_pkg.join('setup.py').write(dedent("""\
+        import sys
         from os.path import join
         from setuptools import setup, Extension
+        sys.path.insert(0, '{astropy_helpers_path}')
         from astropy_helpers.setup_helpers import register_commands, get_package_info
 
         NAME = '_welltall_'
@@ -381,7 +386,7 @@ def test_command_hooks(tmpdir, capsys):
             version=VERSION,
             cmdclass=cmdclassd
         )
-    """))
+    """.format(astropy_helpers_path=ASTROPY_HELPERS_PATH)))
 
     with test_pkg.as_cwd():
         try:
@@ -536,8 +541,10 @@ def test_invalid_package_exclusion(tmpdir, capsys):
 
     module_name = 'foobar'
     setup_header = dedent("""\
+        import sys
         from os.path import join
         from setuptools import setup, Extension
+        sys.path.insert(0, '{astropy_helpers_path}')
         from astropy_helpers.setup_helpers import register_commands, \\
             get_package_info, add_exclude_packages
 
@@ -545,7 +552,7 @@ def test_invalid_package_exclusion(tmpdir, capsys):
         VERSION = 0.1
         RELEASE = True
 
-    """.format(module_name=module_name))
+    """.format(module_name=module_name, astropy_helpers_path=ASTROPY_HELPERS_PATH))
 
     setup_footer = dedent("""\
         setup(


### PR DESCRIPTION
In various packages using astropy-helpers it is possible in some cases to trigger a segmentation fault when the submodule is first initialized. This is described in more detail in https://github.com/cython/cython/issues/2104

The bottom line is that this seems to be due to the interaction between setuptools' ``run_setup`` command and Cython, and the following script fails on various combinations of Cython and setuptools:

```python
import os

with open('test.pyx', 'w') as f:
    f.write('cimport cython\n')

with open('test.py', 'w') as f:
    f.write('import Cython.Compiler.Main')

from setuptools.sandbox import run_setup
run_setup(os.path.join(os.path.abspath('.'), 'test.py'), ['egg_info'])

from Cython.Build import cythonize
cythonize('test.pyx')
```

This PR updates ``ah_bootstrap.py`` to use ``subprocess`` instead of ``run_setup``, which works just as well. The test suite was also updated to use ``subprocess`` otherwise the use of ``subprocess`` in ``ah_bootstrap.py`` raised a sandbox violation error.

In any case, I'm actually happier with using subprocess since this keeps things more self-contained, especially when it comes to the tests.

For anyone reviewing this, most of the changes are to the tests, but the main change to check is the one in ``ah_bootstrap.py``.