### PR TITLE
Fix package exclusion behavior in our own setup.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,7 +39,7 @@ astropy-helpers Changelog
 2.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid deprecation warning due to ``exclude=`` keyword in ``setup.py``. [#379]
 
 
 2.0.5 (2018-02-22)

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -129,7 +129,7 @@ def add_exclude_packages(excludes):
             "add_package_excludes must be called before all other setup helper "
             "functions in order to properly handle excluded packages")
 
-    _module_state['exclude_packages'].add(set(excludes))
+    _module_state['exclude_packages'].update(set(excludes))
 
 
 def register_commands(package, version, release, srcdir='.'):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@
 import ah_bootstrap
 import pkg_resources
 from setuptools import setup
-from astropy_helpers.setup_helpers import register_commands, get_package_info
+from astropy_helpers.setup_helpers import (register_commands, get_package_info,
+                                           add_exclude_packages)
 from astropy_helpers.version_helpers import generate_version_py
 
 NAME = 'astropy_helpers'
@@ -16,6 +17,7 @@ generate_version_py(NAME, VERSION, RELEASE, False, uses_git=not RELEASE)
 # Use the updated version including the git rev count
 from astropy_helpers.version import version as VERSION
 
+add_exclude_packages(['astropy_helpers.tests'])
 cmdclass = register_commands(NAME, VERSION, RELEASE)
 # This package actually doesn't use the Astropy test command
 del cmdclass['test']
@@ -47,5 +49,5 @@ setup(
     cmdclass=cmdclass,
     python_requires='>=3.5',
     zip_safe=False,
-    **get_package_info(exclude=['astropy_helpers.tests'])
+    **get_package_info()
 )


### PR DESCRIPTION
This is somewhat embarrassing, but our own `setup.py` within `astropy_helpers` was using deprecated behavior. This PR fixes it.

This should address the issue reported here, although it will need to be backported to `v2.0.5` if it's not too late: https://github.com/gammapy/gammapy/pull/1264#issuecomment-368108877