### PR TITLE
Don't capture stderr with -w

### DIFF
--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -218,7 +218,7 @@ class AstropyBuildDocs(SphinxBuildDoc):
             proc = subprocess.Popen([sys.executable, '-c', subproccode],
                                     stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE,
-                                    stderr=subprocess.STDOUT)
+                                    stderr=None)
 
             retcode = 1
             with proc.stdout:


### PR DESCRIPTION
The line that the subprocess checks for is in stdout, so we don't need to capture stderr, which allows it to be piped away to hide warnings in the build.

---

fwiw, I am using this in sunpy/sunpy#2553 where I modify the sphinx logger to send sphinx warnings to stdout not stderr, so that I can pipe stderr to `/dev/null` and massively reduce the number of output lines on CI to make it easier for people to find the actual sphinx warnings that are making their builds fail.