### PR TITLE
Add warning file argument to build_docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ astropy-helpers Changelog
   by the ``sphinx-astropy`` package in conjunction with the ``astropy-theme-sphinx``,
   ``sphinx-automodapi``, and ``numpydoc`` packages. [#368]
 
+- Added the ``--warning-file`` option to the ``build_docs`` command, which
+  allows sphinx warnings to be output to a file. (It also outputs the result
+  of that file when run on travis.) [#383]
+
 
 3.0.2 (unreleased)
 ------------------

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -263,12 +263,19 @@ class AstropyBuildDocs(SphinxBuildDoc):
                     # this means we are in the travis build, so customize
                     # the message appropriately.
                     msg = ('The build_docs travis build FAILED '
-                           'because sphinx issued documentation '
-                           'warnings (scroll up to see the warnings).')
+                           'because sphinx issued documentation warnings. '
+                           'Scroll up to see the warnings in context.')
+                    if self.warning_file:
+                        msg += 'Warnings/errors are also listed below:\n'
+                        with open(os.path.abspath(self.warning_file)) as f:
+                            msg += f.read()
                 else:  # standard failure message
                     msg = ('build_docs returning a non-zero exit '
                            'code because sphinx issued documentation '
                            'warnings.')
+                    if self.warning_file:
+                        fn = os.path.abspath(self.warning_file)
+                        msg += ' Warnings recorded in file: "{}"'.format(fn)
                 log.warn(msg)
 
         else:

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -134,7 +134,6 @@ class AstropyBuildDocs(SphinxBuildDoc):
         # Now generate the source for and spawn a new process that runs the
         # command.  This is needed to get the correct imports for the built
         # version
-        runlines, runlineno = inspect.getsourcelines(SphinxBuildDoc.run)
         subproccode = textwrap.dedent("""
             from sphinx.setup_command import *
 
@@ -182,6 +181,11 @@ class AstropyBuildDocs(SphinxBuildDoc):
             for egg in glob.glob(os.path.join(eggs_path, '*.egg')):
                 subproccode += 'sys.path.append({egg!r})\n'.format(egg=egg)
 
+        # Somewhat hacky: extract the lines to actually run the command from the
+        # run method of SphinxBuildDoc.  This is necessary because there aren't
+        # enough interediate steps inside `run` that we can override in this
+        # subclass, so we pull out the source and modify it at the string level.
+        runlines, runlineno = inspect.getsourcelines(SphinxBuildDoc.run)
         # runlines[1:] removes 'def run(self)' on the first line
         subproccode += textwrap.dedent(''.join(runlines[1:]))
 


### PR DESCRIPTION
This PR adds an option to output a "warnings file" from the `build_docs` command. (Inspired by the similar option that now exists in the ``sphinx-build`` command line tool.)  

Much more importantly, when used on travis, it will also automatically output the results of that command at the end of the travis build log.  This will make it so that docs build failures no longer require hunting through a thousand lines of output: the warnings and *only* the warnings will be at the bottom of the build log.

To activate this in astropy will require a second PR that just modifies the travis matrix to add an argument like `` --warning-file warnings.out`` to the `build_docs` command.  Will do that myself if this PR is approved.

@astrofrog @bsipocz - I tentatively milestoned this 3.1.0, since it's a new feature... but we might want this included in the build *before* the 3.1 core package release, as I think it will help quite a bit in diagnosing travis docs failures.  I suppose the PR that updates the travis file can update astropy to this helpers version as an interim solution?

