### PR TITLE
EXP: Add helpers version in version.py

### DIFF
--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -99,6 +99,8 @@ release = {rel}
 timestamp = {timestamp!r}
 debug = {debug}
 
+astropy_helpers_version = "{ahver}"
+
 try:
     from ._compiler import compiler
 except ImportError:
@@ -142,6 +144,11 @@ githash = "{githash}"
 
 def _get_version_py_str(packagename, version, githash, release, debug,
                         uses_git=True):
+    try:
+        from astropy_helpers import __version__ as ahver
+    except ImportError:
+        ahver = "unknown"
+
     epoch = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
     timestamp = datetime.datetime.utcfromtimestamp(epoch)
     major, minor, bugfix = _version_split(version)
@@ -172,6 +179,7 @@ def _get_version_py_str(packagename, version, githash, release, debug,
                                               major=major,
                                               minor=minor,
                                               bugfix=bugfix,
+                                              ahver=ahver,
                                               rel=release, debug=debug)
 
 


### PR DESCRIPTION
This is needed for astropy/astropy#7392

~~I need to see Travis CI over there before deciding if this really works.~~ (I think it works!) Locally, I see:
```
Numpy: 1.14.1
Scipy: 1.0.0
Matplotlib: 2.1.1
h5py: 2.7.0
Pandas: 0.20.3
Asdf: 2.0.0.dev1248
Cython: 0.26.1
astropy_helpers: 3.0.1
Using Astropy options: remote_data: none.
```