### PR TITLE
Move clone of ci-helpers to script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
 
 install:
 
-    - git clone git://github.com/astropy/ci-helpers.git
+    - source scripts/get_ci-helpers.sh
     - source ci-helpers/travis/setup_conda.sh
 
     # We cannot install the developer version of setuptools using pip because

--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -1,0 +1,8 @@
+Scripts
+=======
+
+This dir is designed to contain only scripts.
+
+Ideally it should contain only those scripts generic and necessary to
+``astropy-helpers``, i.e. ``get_ci-helpers.sh``. Any script less generic, e.g.
+those used for CI, should live elsewhere, e.g. https://github.com/astropy/ci-helpers.

--- a/scripts/get_ci-helpers.sh
+++ b/scripts/get_ci-helpers.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Check whethere ci-helpers has already been cloned, if not, clone.
+# Assumes working dir is correct
+
+if [ ! -d "ci-helpers" ]; then git clone --depth 1 git://github.com/astropy/ci-helpers.git; fi


### PR DESCRIPTION
If astropy/ci-helpers is needed, it would useful to have the clone
contained as reusable functionality. This function first checks to
see if it has already been cloned before doing so.

Signed-off-by: James Noss <jnoss@stsci.edu>