### PR TITLE
Use intersphinx of released version rather than dev

### DIFF
--- a/astropy_helpers/sphinx/conf.py
+++ b/astropy_helpers/sphinx/conf.py
@@ -55,7 +55,7 @@ intersphinx_mapping = {
     'matplotlib': ('http://matplotlib.org/',
                    (None, 'http://data.astropy.org/intersphinx/matplotlib.inv')),
     'astropy': ('http://docs.astropy.org/en/stable/', None),
-    'h5py': ('http://docs.h5py.org/en/latest/', None)}
+    'h5py': ('http://docs.h5py.org/en/stable/', None)}
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
This PR should be backported to the 2.0.x branch, too, but shouldn't go into master given that the intersphinx mapping was already been refactored out to `sphinx-astropy`. 