### PR TITLE
Fix backport for minimum python version

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -45,7 +45,7 @@ import re
 import subprocess as sp
 import sys
 
-__minimum_python_version__ = (3, 5)
+__minimum_python_version__ = (2, 7)
 
 if sys.version_info < __minimum_python_version__:
     print("ERROR: Python {} or later is required by astropy-helpers".format(


### PR DESCRIPTION
This should have been edited during backport, but now I prefer to double check whether it works with all CI.