### PR TITLE
Extend exception handling of OpenMP support check

### DIFF
--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -206,7 +206,7 @@ def check_openmp_support(openmp_flags=None):
             log.warn("Unexpected output from test OpenMP "
                      "program (output was {0})".format(output))
             is_openmp_supported = False
-    except (CompileError, LinkError):
+    except (CompileError, LinkError, subprocess.CalledProcessError):
         is_openmp_supported = False
 
     finally:


### PR DESCRIPTION
``openmp_helpers.check_openmp_support()`` compiles and links the small C code to test
OpenMP support. If either of these stages fail, their exceptions are caught and
``is_openmp_supported = False`` is set. However, they may still pass but the
code fails to run. ``CalledProcessError`` also needs to be caught to deal with
this.

Signed-off-by: James Noss <jnoss@stsci.edu>