### PR TITLE
Adding python3.7 to the CI matrixes to make sure we're compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ sudo: false
 env:
   matrix:
     - PYTHON_VERSION=3.5
-    - PYTHON_VERSION=3.6 SETUPTOOLS_VERSION=dev DEBUG=True
+    - PYTHON_VERSION=3.6
+    - PYTHON_VERSION=3.7 SETUPTOOLS_VERSION=dev DEBUG=True
       CONDA_DEPENDENCIES='sphinx cython numpy pytest-cov'
       EVENT_TYPE='push pull_request cron'
+
 
   global:
     - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ environment:
   matrix:
       - PYTHON_VERSION: "3.5"
       - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "3.7"
 
 platform:
     -x64


### PR DESCRIPTION
Python3.7 compatibility ideally needs to be checked before doing the new core releases...