### PR TITLE
Fix bug when running setup.py without numpy installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ matrix:
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx coveralls'
            CONDA_DEPENDENCIES="setuptools cython numpy pytest-cov"
+    # Test without installing numpy beforehand to make sure everything works
+    # without assuming numpy is already installed
+    - os: linux
+      env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='sphinx cython pytest-cov'
 
     # Test conda's clang
     - os: osx

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,7 +57,8 @@ astropy-helpers Changelog
 2.0.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed error that occurs when installing a package in an environment where
+  ``numpy`` is not already installed. [#404]
 
 
 2.0.7 (2018-06-01)

--- a/astropy_helpers/commands/build_ext.py
+++ b/astropy_helpers/commands/build_ext.py
@@ -289,9 +289,11 @@ def generate_build_ext_command(packagename, release):
         def run(self):
             # For extensions that require 'numpy' in their include dirs,
             # replace 'numpy' with the actual paths
-            np_include = get_numpy_include_path()
+            np_include = None
             for extension in self.extensions:
                 if 'numpy' in extension.include_dirs:
+                    if np_include is None:
+                        np_include = get_np_include_path()
                     idx = extension.include_dirs.index('numpy')
                     extension.include_dirs.insert(idx, np_include)
                     extension.include_dirs.remove('numpy')


### PR DESCRIPTION
This fixes #402. Thanks @saimn for identifying the fix.