### PR TITLE
Clean up old python compatibilities

### DIFF
--- a/astropy_helpers/commands/build_ext.py
+++ b/astropy_helpers/commands/build_ext.py
@@ -10,10 +10,11 @@ import textwrap
 from distutils import log, ccompiler, sysconfig
 from distutils.core import Extension
 from distutils.ccompiler import get_default_compiler
+from importlib import invalidate_caches
 from setuptools.command.build_ext import build_ext as SetuptoolsBuildExt
 from setuptools.command import build_py
 
-from ..utils import get_numpy_include_path, invalidate_caches, classproperty
+from ..utils import get_numpy_include_path, classproperty
 from ..version_helpers import get_pkg_version_module
 
 

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -20,7 +20,6 @@ try:
 except ImportError:
     import_machinery = None
 
-from importlib import invalidate_caches
 
 
 # Note: The following Warning subclasses are simply copies of the Warnings in

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -12,14 +12,7 @@ import textwrap
 import types
 import warnings
 
-try:
-    from importlib import machinery as import_machinery
-    # Python 3.2 does not have SourceLoader
-    if not hasattr(import_machinery, 'SourceLoader'):
-        import_machinery = None
-except ImportError:
-    import_machinery = None
-
+from importlib import machinery as import_machinery
 
 
 # Note: The following Warning subclasses are simply copies of the Warnings in

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -28,12 +28,12 @@ import sys
 import time
 
 from distutils import log
+from importlib import invalidate_caches
 
 import pkg_resources
 
 from . import git_helpers
 from .distutils_helpers import is_distutils_display_option
-from .utils import invalidate_caches
 
 
 def _version_split(version):


### PR DESCRIPTION
The code has been removed from utils for invalidate_caches compatibility, so we better import it directly from importlib.

Also removed other Python <3.3 compatibility workaround (that was problematic anyway as the attribute is called SourceFileLoader rather than SourceLoader)

