### PR TITLE
Simplify build_docs command to avoid patching code from Sphinx

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ astropy-helpers Changelog
 3.1 (unreleased)
 ----------------
 
+- Fixed the compability of the build_docs command with Sphinx 1.8 and above. [#413]
+
 - Removing deprecated test_helpers.py file. [#369]
 
 - Removing ez_setup.py file and requiring setuptools 1.0 or later. [#384]

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -149,12 +149,12 @@ class AstropyBuildDocs(SphinxBuildDoc):
             dist = Distribution()
             eggs = dist.fetch_build_eggs('sphinx-astropy')
             # Find out the version of sphinx-astropy
-            for egg in eggs:
-                if egg.project_name == 'sphinx-astropy':
-                    sphinx_astropy_version = egg.parsed_version.public
-                    break
-            else:
-                sphinx_astropy_version = '0'
+            sphinx_astropy_version = '0'
+            if eggs is not None:
+                for egg in eggs:
+                    if egg.project_name == 'sphinx-astropy':
+                        sphinx_astropy_version = egg.parsed_version.public
+                        break
             # Note that we use append below because we want to make sure that if
             # a user runs a build which populates the .eggs directory, *then*
             # installs sphinx-astropy at the system-level, we want to make sure

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -23,10 +23,6 @@ class AstropyBuildDocs(SphinxBuildDoc):
     that is built by the setup ``build`` command, rather than whatever is
     installed on the system.  To build docs against the installed version, run
     ``make html`` in the ``astropy/docs`` directory.
-
-    This also automatically creates the docs/_static directories--this is
-    needed because GitHub won't create the _static dir because it has no
-    tracked files.
     """
 
     description = 'Build Sphinx documentation for Astropy environment'
@@ -161,7 +157,7 @@ class AstropyBuildDocs(SphinxBuildDoc):
                 argv = ['-W', '.', '-b', builder, os.path.join({output_dir!r}, builder)]
                 build_main(argv=argv)
         """.format(builders=self.builder,
-                   output_dir=os.path.relpath(self.build_dir, 'docs')))
+                   output_dir=os.path.abspath(self.build_dir)))
 
         log.debug('Starting subprocess of {0} with python code:\n{1}\n'
                   '[CODE END])'.format(sys.executable, subproccode))

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -20,7 +20,6 @@ from ..utils import AstropyDeprecationWarning
 
 SPHINX_LT_17 = LooseVersion(__version__) < LooseVersion('1.7')
 
-
 SUBPROCESS_CODE = """
 import os
 import sys

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -182,6 +182,12 @@ class AstropyBuildDocs(SphinxBuildDoc):
         if self.traceback:
             argv.append('-T')
 
+        # The default verbosity level is 1, so in that case we just don't add a flag
+        if self.verbose == 0:
+            argv.append('-q')
+        elif self.verbose > 1:
+            argv.append('-v')
+
         if SPHINX_LT_17:
             argv.insert(0, 'sphinx-build')
 

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -172,10 +172,10 @@ class AstropyBuildDocs(SphinxBuildDoc):
         if self.all_files:
             argv.append('-a')
 
-        if self.pdb:
+        if getattr(self, 'pdb', False):
             argv.append('-P')
 
-        if self.nitpicky:
+        if getattr(self, 'nitpicky', False):
             argv.append('-n')
 
         if self.traceback:
@@ -190,10 +190,15 @@ class AstropyBuildDocs(SphinxBuildDoc):
         if SPHINX_LT_17:
             argv.insert(0, 'sphinx-build')
 
+        if isinstance(self.builder, str):
+            builders = [self.builder]
+        else:
+            builders = self.builder
+
         subproccode = SUBPROCESS_CODE.format(build_main=build_main,
                                              srcdir=self.source_dir,
                                              sys_path_inserts=sys_path_inserts,
-                                             builders=self.builder,
+                                             builders=builders,
                                              argv=argv,
                                              output_dir=os.path.abspath(self.build_dir))
 

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -12,14 +12,14 @@ from distutils.version import LooseVersion
 
 from distutils import log
 
-from sphinx import __version__
+from sphinx import __version__ as sphinx_version
 from sphinx.setup_command import BuildDoc as SphinxBuildDoc
 
 from ..utils import AstropyDeprecationWarning
 
-SPHINX_LT_17 = LooseVersion(__version__) < LooseVersion('1.7')
+SPHINX_LT_17 = LooseVersion(sphinx_version) < LooseVersion('1.7')
 
-SUBPROCESS_CODE = """
+SUBPROCESS_TEMPLATE = """
 import os
 import sys
 
@@ -226,7 +226,7 @@ class AstropyBuildDocs(SphinxBuildDoc):
         else:
             builders = self.builder
 
-        subproccode = SUBPROCESS_CODE.format(build_main=build_main,
+        subproccode = SUBPROCESS_TEMPLATE.format(build_main=build_main,
                                              srcdir=self.source_dir,
                                              sys_path_inserts=sys_path_inserts,
                                              builders=builders,

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -162,7 +162,11 @@ class AstropyBuildDocs(SphinxBuildDoc):
         argv = []
 
         if self.warnings_returncode:
-            argv.extend(['-W'])
+            argv.append('-W')
+
+        if self.no_intersphinx:
+            # NOTE: this requires sphinx-astropy>=1.1
+            argv.extend(['-D', 'disable_intersphinx=1'])
 
         # We now need to adjust the flags based on the parent class's options
 

--- a/astropy_helpers/tests/__init__.py
+++ b/astropy_helpers/tests/__init__.py
@@ -79,6 +79,9 @@ def run_setup(setup_script, args):
     sys.stdout.write(stdout.decode('utf-8'))
     sys.stderr.write(stderr.decode('utf-8'))
 
+    if p.returncode != 0:
+        raise SystemExit(p.returncode)
+
 
 @pytest.fixture(scope='function', autouse=True)
 def reset_setup_helpers(request):

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -246,7 +246,8 @@ def test_missing_cython_c_files(capsys, pyx_extension_test_package, monkeypatch)
 
     with test_pkg.as_cwd():
 
-        run_setup('setup.py', ['build_ext', '--inplace', '--no-cython'])
+        with pytest.raises(SystemExit):
+            run_setup('setup.py', ['build_ext', '--inplace', '--no-cython'])
 
         stdout, stderr = capsys.readouterr()
         assert "No git repository present at" in stderr
@@ -564,7 +565,8 @@ def test_invalid_package_exclusion(tmpdir, capsys):
         setup_header + error_commands + setup_footer)
 
     with error_pkg.as_cwd():
-        run_setup('setup.py', ['build'])
+        with pytest.raises(SystemExit):
+            run_setup('setup.py', ['build'])
 
         stdout, stderr = capsys.readouterr()
         assert "RuntimeError" in stderr

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -289,6 +289,7 @@ def test_build_docs(capsys, tmpdir, mode):
             warnings.simplefilter("ignore")
             from sphinx_astropy.conf import *
         exclude_patterns.append('_templates')
+        suppress_warnings = ['app.add_directive', 'app.add_node', 'app.add_role']
     """))
 
     if mode == 'cli-error':


### PR DESCRIPTION
Prior to this, we were live-patching code from Sphinx, which seems very brittle. The subprocess code now uses public Sphinx API to do its thing.

This appears to solve https://github.com/astropy/sphinx-astropy/issues/12 - the issue that the docs were currently being built in ``docs/docs/_build/html``.

At the moment this breaks the ``no_intersphinx`` feature because it's not trivial to do this via the ``sphinx-build`` API. I'm curious whether people use this?

I also need to add back to creating of ``_static`` if it's actually needed (not sure if it is anymore)