### PR TITLE
Using deprecated imp rather than importlib for python2 compatibility

### DIFF
--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -143,7 +143,14 @@ def extension_test_package(tmpdir, request):
 @pytest.fixture
 def c_extension_test_package(tmpdir, request):
     # Check whether numpy is installed in the test environment
-    has_numpy = bool(imp.find_module('numpy'))
+
+    # For Python2 compatibility we need to do this hack rather than using
+    # importlib.util.find_spec without the try/except
+    try:
+        has_numpy = bool(imp.find_module('numpy'))
+    except ImportError:
+        has_numpy = False
+
     return _extension_test_package(tmpdir, request, extension_type='c',
                                    include_numpy=has_numpy)
 

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -2,7 +2,7 @@ import os
 import sys
 import stat
 import shutil
-import importlib
+import imp
 import contextlib
 
 import pytest
@@ -143,7 +143,7 @@ def extension_test_package(tmpdir, request):
 @pytest.fixture
 def c_extension_test_package(tmpdir, request):
     # Check whether numpy is installed in the test environment
-    has_numpy = bool(importlib.find_loader('numpy'))
+    has_numpy = bool(imp.find_module('numpy'))
     return _extension_test_package(tmpdir, request, extension_type='c',
                                    include_numpy=has_numpy)
 


### PR DESCRIPTION
This should fix the CI failures on python2. This still supposed to work with later pythons (tested with 3.7 locally), but if any issues come up I'll switch back to use importlib for the python3 cases.