### PR TITLE
Check that docs are generated in the correct location

### DIFF
--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -258,7 +258,7 @@ def test_missing_cython_c_files(capsys, pyx_extension_test_package, monkeypatch)
         assert msg in stderr
 
 
-@pytest.mark.parametrize('mode', ['cli', 'cli-w', 'deprecated', 'cli-l', 'cli-error'])
+@pytest.mark.parametrize('mode', ['cli', 'cli-w', 'deprecated', 'cli-l'])
 def test_build_docs(capsys, tmpdir, mode):
     """
     Test for build_docs
@@ -292,11 +292,6 @@ def test_build_docs(capsys, tmpdir, mode):
         exclude_patterns.append('_templates')
         suppress_warnings = ['app.add_directive', 'app.add_node', 'app.add_role']
     """))
-
-    if mode == 'cli-error':
-        docs_dir.join('conf.py').write(dedent("""
-        raise ValueError("TestException")
-        """))
 
     docs_dir.join('index.rst').write(dedent("""\
         .. automodapi:: mypackage
@@ -336,6 +331,8 @@ def test_build_docs(capsys, tmpdir, mode):
             run_setup('setup.py', ['build_sphinx'])
             stdout, stderr = capsys.readouterr()
             assert 'AstropyDeprecationWarning' in stderr
+
+    assert os.path.exists(docs_dir.join('_build', 'html', 'index.html').strpath)
 
 
 def test_command_hooks(tmpdir, capsys):


### PR DESCRIPTION
This is a regression test for https://github.com/astropy/astropy-helpers/issues/415 - it passes in master but fails on v2.0.x. I'll work on a fix for v2.0.x now.