### PR TITLE
Fix docs build with Sphinx 1.8+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ astropy-helpers Changelog
 2.0.8 (unreleased)
 ------------------
 
+- Fixed compatibility with Sphinx 1.8+. [#428]
+
 - Fixed error that occurs when installing a package in an environment where
   ``numpy`` is not already installed. [#404]
 

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -71,6 +71,13 @@ class AstropyBuildDocs(SphinxBuildDoc):
 
     def finalize_options(self):
 
+        # We need to make sure this is set before finalize_options otherwise
+        # the default is set to build/sphinx. We also need the absolute path
+        # as in some Sphinx versions, the path is otherwise interpreted as
+        # docs/docs/_build.
+        if self.build_dir is None:
+            self.build_dir = os.path.abspath('docs/_build')
+
         SphinxBuildDoc.finalize_options(self)
 
         # Clear out previous sphinx builds, if requested

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -274,6 +274,8 @@ def test_build_docs(capsys, tmpdir, mode):
     Test for build_docs
     """
 
+    AH_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
     test_pkg = tmpdir.mkdir('test_pkg')
 
     test_pkg.mkdir('mypackage')
@@ -301,13 +303,13 @@ def test_build_docs(capsys, tmpdir, mode):
     docs_dir = test_pkg.join('docs')
     docs_dir.join('conf.py').write(dedent("""\
         import sys
-        sys.path.append("../")
+        sys.path.insert(0, '{0}')
         import warnings
         with warnings.catch_warnings():  # ignore matplotlib warning
             warnings.simplefilter("ignore")
             from astropy_helpers.sphinx.conf import *
         exclude_patterns.append('_templates')
-    """))
+    """.format(AH_PATH)))
 
     docs_dir.join('index.rst').write(dedent("""\
         .. automodapi:: mypackage

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -274,8 +274,6 @@ def test_build_docs(capsys, tmpdir, mode):
     Test for build_docs
     """
 
-    AH_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-
     test_pkg = tmpdir.mkdir('test_pkg')
 
     test_pkg.mkdir('mypackage')
@@ -303,13 +301,13 @@ def test_build_docs(capsys, tmpdir, mode):
     docs_dir = test_pkg.join('docs')
     docs_dir.join('conf.py').write(dedent("""\
         import sys
-        sys.path.insert(0, '{0}')
+        sys.path.insert(0, r'{0}')
         import warnings
         with warnings.catch_warnings():  # ignore matplotlib warning
             warnings.simplefilter("ignore")
             from astropy_helpers.sphinx.conf import *
         exclude_patterns.append('_templates')
-    """.format(AH_PATH)))
+    """.format(ASTROPY_HELPERS_PATH)))
 
     docs_dir.join('index.rst').write(dedent("""\
         .. automodapi:: mypackage


### PR DESCRIPTION
This is a quick fix for #415 that doesn't rely on backporting https://github.com/astropy/astropy-helpers/pull/413 (which is virtually impossible without backporting most other things)

Fun fact: the build_docs test actually to have been broken for a while since the astropy_helpers import didn't work... Fixed now though (and not relevant in master since the docs build no longer uses astropy-helpers).

Fixes #415 