### PR TITLE
Fix get_compiler_option import

### DIFF
--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -26,7 +26,7 @@ from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler, get_config_var
 from distutils.errors import CompileError, LinkError
 
-from .setup_helpers import get_compiler_option
+from .distutils_helpers import get_compiler_option
 
 __all__ = ['add_openmp_flags_if_available']
 


### PR DESCRIPTION
I noticed that `get_compiler_option` is actually defined in `distutils_helpers.py`. You didn't get an error importing it from `setup_helpers.py` is because the latter imports it for its own use without cleaning its own namespace.