### PR TITLE
Use raw string in regex

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -633,8 +633,8 @@ class _Bootstrapper(object):
         # only if the submodule is initialized.  We ignore this information for
         # now
         _git_submodule_status_re = re.compile(
-            '^(?P<status>[+-U ])(?P<commit>[0-9a-f]{40}) '
-            '(?P<submodule>\S+)( .*)?$')
+            r'^(?P<status>[+-U ])(?P<commit>[0-9a-f]{40}) '
+            r'(?P<submodule>\S+)( .*)?$')
 
         # The stdout should only contain one line--the status of the
         # requested submodule


### PR DESCRIPTION
To get rid of this warning seen in `pytest` summary:

```
astropy_helpers/tests/test_ah_bootstrap.py::test_download_if_needed
  .../ah_bootstrap.py:637: DeprecationWarning: invalid escape sequence \S
    '(?P<submodule>\S+)( .*)?$')
```