### PR TITLE
Simplify API for register_commands and generate_version_py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ matrix:
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='codecov sphinx-astropy'
     - os: linux
-      env: PYTHON_VERSION=3.6 SPHINX_VERSION='1.5' SETUPTOOLS_VERSION=27
+      env: PYTHON_VERSION=3.6 SPHINX_VERSION='1.5' SETUPTOOLS_VERSION=30
     - os: linux
-      env: PYTHON_VERSION=3.5 SPHINX_VERSION='1.4' SETUPTOOLS_VERSION=27
+      env: PYTHON_VERSION=3.5 SPHINX_VERSION='1.4' SETUPTOOLS_VERSION=30
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx codecov'
            CONDA_DEPENDENCIES="setuptools cython numpy pytest-cov"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ astropy-helpers Changelog
 
 - Make it possible to call ``generate_version_py`` and ``register_commands``
   without any arguments, which causes information to be read in from the
-  ``setup.cfg`` file.
+  ``setup.cfg`` file. [#440]
 
 - Remove functionality to adjust compilers if a broken compiler is detected.
   This is not useful anymore as only a single compiler was previously patched

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ astropy-helpers Changelog
 3.2 (unreleased)
 ----------------
 
+- Make it possible to call ``generate_version_py`` and ``register_commands``
+  without any arguments, which causes information to be read in from the
+  ``setup.cfg`` file.
+
 - Remove functionality to adjust compilers if a broken compiler is detected.
   This is not useful anymore as only a single compiler was previously patched
   (now unlikely to be used) and this was only to fix a compilation issue in the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ astropy-helpers Changelog
   without any arguments, which causes information to be read in from the
   ``setup.cfg`` file. [#440]
 
+- Updated minimum required version of setuptools to 30.3.0. [#440]
+
 - Remove functionality to adjust compilers if a broken compiler is detected.
   This is not useful anymore as only a single compiler was previously patched
   (now unlikely to be used) and this was only to fix a compilation issue in the

--- a/README.rst
+++ b/README.rst
@@ -68,11 +68,18 @@ commands described here, add::
 
 to your ``setup.py`` file, then do::
 
+    # Create a dictionary with setup command overrides. Note that this gets
+    # information about the package (name and version) from the setup.cfg file.
     cmdclassd = register_commands()
 
 This function requires that the package name and full version are set in the
-``setup.cfg`` file in the ``[metadata]`` section. Then, pass ``cmdclassd`` to
-the ``setup`` function::
+``setup.cfg`` file in the ``[metadata]`` section, e.g.::
+
+    [metadata]
+    name = mypackage
+    version = 0.4.dev
+
+Then, pass ``cmdclassd`` to the ``setup`` function in ``setup.py``::
 
      setup(...,
            cmdclass=cmdclassd)
@@ -165,12 +172,20 @@ several other complementary variables. To use this, import::
 
 in your ``setup.py`` file, and call::
 
+    # Freeze build information in version.py. Note that this gets information
+    # about the package (name and version) from the setup.cfg file.
     version = generate_version_py()
 
 The ``version`` variable will be set to the version number of your package
 including any developer suffix. Note that this requires that the package name
-and version are set in the ``setup.cfg`` file in the ``[metadata]`` section.
-Then, pass ``version`` to the ``setup`` function::
+and version are set in the ``setup.cfg`` file in the ``[metadata]`` section,
+e.g.::
+
+    [metadata]
+    name = mypackage
+    version = 0.4.dev
+
+Then, pass ``version`` to the ``setup`` function in ``setup.py``::
 
      setup(...,
            version=version)
@@ -359,10 +374,10 @@ package that already uses astropy-helpers, install astropy-helpers from your
 branch of the repository in editable mode::
 
     pip install -e .
-    
+
 Then go to your package and add the ``--use-system-astropy-helpers`` for any
 ``setup.py`` command you want to check, e.g.::
 
     python setup.py build_docs --use-system-astropy-helpers
-    
+
 This will cause the installed version to be used instead of any local submodule.

--- a/README.rst
+++ b/README.rst
@@ -68,12 +68,11 @@ commands described here, add::
 
 to your ``setup.py`` file, then do::
 
-    cmdclassd = register_commands(NAME, VERSION, RELEASE)
+    cmdclassd = register_commands()
 
-where ``NAME`` is the name of your package, ``VERSION`` is the full version
-string, and ``RELEASE`` is a boolean value indicating whether the version is
-a stable released version (``True``) or a developer version (``False``).
-Finally, pass ``cmdclassd`` to the ``setup`` function::
+Note that this requires that the package name and version are set in the
+``setup.cfg`` file in the ``[metadata]`` section. Then, pass ``cmdclassd`` to
+the ``setup`` function::
 
      setup(...,
            cmdclass=cmdclassd)
@@ -151,38 +150,30 @@ Version helpers
 ^^^^^^^^^^^^^^^^
 
 Another piece of functionality we provide in astropy-helpers is the ability
-to generate a ``packagename.version`` file that includes functions that
+to generate a ``packagename.version`` module that includes functions that
 automatically set the version string for developer versions, to e.g.
 ``3.2.dev22213`` so that each developer version has a unique number (although
 note that branches an equal number of commits away from the master branch will
-share the same version number). To use this, import::
+share the same version number).
 
-    from astropy_helpers.git_helpers import get_git_devstr
-
-in your ``setup.py`` file, and you will then be able to use::
-
-    VERSION += get_git_devstr()
-
-where ``VERSION`` is a version string without any developer version suffix.
-
-We then also provide a function that generates a ``version.py`` file inside your
-package (which can then be imported as ``packagename.version``) that contains
-variables such as ``major``, ``minor``, and ``bugfix``, as well as
-``version_info`` (a tuple of the previous three values), a ``release`` flag that
-indicates whether we are using a stable release, and several other complementary
-variables. To use this, import::
+In addition, this module contains variables such as ``major``, ``minor``, and
+``bugfix``, as well as ``version_info`` (a tuple of the previous three values),
+a ``release`` flag that indicates whether we are using a stable release, and
+several other complementary variables. To use this, import::
 
     from astropy_helpers.version_helpers import generate_version_py
 
 in your ``setup.py`` file, and call::
 
-    generate_version_py(NAME, VERSION, RELEASE, uses_git=not RELEASE)
+    version = generate_version_py()
 
-where ``NAME`` is the name of your package, ``VERSION`` is the full version string
-(including any developer suffix), ``RELEASE`` indicates whether the version is a
-stable or developer version, and ``uses_git`` indicates whether we are in a git
-repository (using ``not RELEASE`` is sensible since git is not available in a
-stable release).
+The ``version`` variable will be set to the version number of your package
+including any developer suffix. Note that this requires that the package name
+and version are set in the ``setup.cfg`` file in the ``[metadata]`` section.
+Then, pass ``version`` to the ``setup`` function::
+
+     setup(...,
+           version=version)
 
 Collecting package information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ to your ``setup.py`` file, then do::
 
     cmdclassd = register_commands()
 
-Note that this requires that the package name and version are set in the
+This function requires that the package name and full version are set in the
 ``setup.cfg`` file in the ``[metadata]`` section. Then, pass ``cmdclassd`` to
 the ``setup`` function::
 

--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,18 @@ Then, pass ``version`` to the ``setup`` function in ``setup.py``::
      setup(...,
            version=version)
 
+Note that if you want to be able to generate developer versions such as
+``3.2.dev22213`` without having to use the ``generate_version_py`` machinery,
+you can instead just import the following helper function::
+
+    from astropy_helpers.git_helpers import get_git_devstr
+
+and you will then be able to use e.g.::
+
+    version += get_git_devstr()
+
+to add the developer suffix to the version string.
+
 Collecting package information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -151,9 +151,9 @@ from distutils.version import LooseVersion
 
 try:
     import setuptools
-    assert LooseVersion(setuptools.__version__) >= LooseVersion('1.0')
+    assert LooseVersion(setuptools.__version__) >= LooseVersion('30.3')
 except (ImportError, AssertionError):
-    print("ERROR: setuptools 1.0 or later is required by astropy-helpers")
+    print("ERROR: setuptools 30.3 or later is required by astropy-helpers")
     sys.exit(1)
 
 # typing as a dependency for 1.6.1+ Sphinx causes issues when imported after

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -115,6 +115,10 @@ def add_exclude_packages(excludes):
 
 
 def register_commands(package=None, version=None, release=None, srcdir='.'):
+    """
+    This function generates a dictionary containing customized commands that
+    can then be passed to the ``cmdclass`` argument in ``setup()``.
+    """
 
     if package is None or release is None:
 

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -121,9 +121,21 @@ def register_commands(package=None, version=None, release=None, srcdir='.'):
         conf = read_configuration('setup.cfg')
 
         if package is None:
-            package = conf['metadata']['name']
+            if 'name' in conf['metadata']:
+                package = conf['metadata']['name']
+            elif 'package_name' in conf['metadata']:
+                # The package-template used package_name instead of name for a while
+                package = conf['metadata']['package_name']
+            else:
+                print('ERROR: Could not read package name from setup.cfg', file=sys.stderr)
+                sys.exit(1)
+
         if release is None:
-            version = conf['metadata']['version']
+            if 'version' in conf['metadata']:
+                version = conf['metadata']['version']
+            else:
+                print('ERROR: Could not read package version from setup.cfg', file=sys.stderr)
+                sys.exit(1)
             release = 'dev' not in version
 
     if _module_state['registered_commands'] is not None:

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -21,6 +21,7 @@ from distutils.core import Command
 from distutils.command.sdist import sdist as DistutilsSdist
 
 from setuptools import find_packages as _find_packages
+from setuptools.config import read_configuration
 
 from .distutils_helpers import (add_command_option, get_compiler_option,
                                 get_dummy_distribution, get_distutils_build_option,
@@ -113,7 +114,17 @@ def add_exclude_packages(excludes):
     _module_state['exclude_packages'].update(set(excludes))
 
 
-def register_commands(package, version, release, srcdir='.'):
+def register_commands(package=None, version=None, release=None, srcdir='.'):
+
+    if package is None or release is None:
+
+        conf = read_configuration('setup.cfg')
+
+        if package is None:
+            package = conf['metadata']['name']
+        if release is None:
+            version = conf['metadata']['version']
+            release = 'dev' not in version
 
     if _module_state['registered_commands'] is not None:
         return _module_state['registered_commands']

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -296,24 +296,23 @@ def test_build_docs(capsys, tmpdir, mode):
            :no-inheritance-diagram:
     """))
 
+    # For this test we try out the new way of calling register_commands without
+    # arugments, instead getting the information from setup.cfg.
+    test_pkg.join('setup.cfg').write(dedent("""
+        [metadata]
+        name = 'mypackage'
+        version = 0.1
+    """))
+
     test_pkg.join('setup.py').write(dedent("""\
         import sys
         sys.path.insert(0, r'{astropy_helpers_path}')
-        from os.path import join
-        from setuptools import setup, Extension
+        from setuptools import setup
         from astropy_helpers.setup_helpers import register_commands, get_package_info
 
-        NAME = 'mypackage'
-        VERSION = 0.1
-        RELEASE = True
+        cmdclassd = register_commands()
 
-        cmdclassd = register_commands(NAME, VERSION, RELEASE)
-
-        setup(
-            name=NAME,
-            version=VERSION,
-            cmdclass=cmdclassd,
-            **get_package_info()
+        setup(cmdclass=cmdclassd, **get_package_info()
         )
     """.format(astropy_helpers_path=ASTROPY_HELPERS_PATH)))
 

--- a/astropy_helpers/tests/test_setup_helpers.py
+++ b/astropy_helpers/tests/test_setup_helpers.py
@@ -359,7 +359,7 @@ def test_command_hooks(tmpdir, capsys):
         from astropy_helpers.setup_helpers import register_commands, get_package_info
 
         NAME = '_welltall_'
-        VERSION = 0.1
+        VERSION = '0.1'
         RELEASE = True
 
         cmdclassd = register_commands(NAME, VERSION, RELEASE)
@@ -401,7 +401,7 @@ def test_invalid_package_exclusion(tmpdir, capsys):
             get_package_info, add_exclude_packages
 
         NAME = {module_name!r}
-        VERSION = 0.1
+        VERSION = '0.1'
         RELEASE = True
 
     """.format(module_name=module_name, astropy_helpers_path=ASTROPY_HELPERS_PATH))

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -224,10 +224,10 @@ def _generate_git_header(packagename, version, githash):
 
 
 def generate_version_py(packagename=None, version=None, release=None, debug=None,
-                        uses_git=True, srcdir='.'):
+                        uses_git=None, srcdir='.'):
     """Regenerate the version.py module if necessary."""
 
-    if packagename is None or version is None or release is None:
+    if packagename is None or version is None or release is None or uses_git is None:
 
         conf = read_configuration('setup.cfg')
 
@@ -245,6 +245,9 @@ def generate_version_py(packagename=None, version=None, release=None, debug=None
 
         if not release and add_git_devstr:
             version += get_git_devstr(False)
+
+        if uses_git is None:
+            uses_git = not release
 
     try:
         version_module = get_pkg_version_module(packagename)

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -249,6 +249,10 @@ def generate_version_py(packagename=None, version=None, release=None, debug=None
         if uses_git is None:
             uses_git = not release
 
+    # In some cases, packages have a - but this is a _ in the module. Since we
+    # are only interested in the module here, we replace - by _
+    packagename = packagename.replace('-', '_')
+
     try:
         version_module = get_pkg_version_module(packagename)
 

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -225,7 +225,26 @@ def _generate_git_header(packagename, version, githash):
 
 def generate_version_py(packagename=None, version=None, release=None, debug=None,
                         uses_git=None, srcdir='.'):
-    """Regenerate the version.py module if necessary."""
+    """
+    Generate a version.py file in the package with version information, and
+    update developer version strings.
+
+    This function should normally be called without any arguments. In this case
+    the package name and version is read in from the setup.cfg file (from the
+    ``name`` or ``package_name`` entry and the ``version`` entry in the
+    ``[metadata]`` section).
+
+    If the version is a developer version (of the form ``3.2.dev``), the
+    version string will automatically be expanded to include a sequential
+    number as a suffix (e.g. ``3.2.dev13312), and the updated version string
+    will be returned by this function.
+
+    Based on this updated version string, a ``version.py`` file will be
+    generated inside the package, containing the version string as well as more
+    detailed information (for example the major, minor, and bugfix version
+    numbers, a ``release`` flag indicating whether the current version is a
+    stable or developer version, and so on.
+    """
 
     if packagename is None or version is None or release is None or uses_git is None:
 

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -232,10 +232,21 @@ def generate_version_py(packagename=None, version=None, release=None, debug=None
         conf = read_configuration('setup.cfg')
 
         if packagename is None:
-            packagename = conf['metadata']['name']
+            if 'name' in conf['metadata']:
+                packagename = conf['metadata']['name']
+            elif 'package_name' in conf['metadata']:
+                # The package-template used package_name instead of name for a while
+                packagename = conf['metadata']['package_name']
+            else:
+                print('ERROR: Could not read package name from setup.cfg', file=sys.stderr)
+                sys.exit(1)
 
         if version is None:
-            version = conf['metadata']['version']
+            if 'version' in conf['metadata']:
+                version = conf['metadata']['version']
+            else:
+                print('ERROR: Could not read package version from setup.cfg', file=sys.stderr)
+                sys.exit(1)
             add_git_devstr = True
         else:
             add_git_devstr = False


### PR DESCRIPTION
This PR makes it possible to call register_commands and generate_version_py without any arguments, causing the package name and version to instead be read from the setup.cfg file. Also I've retained the old behavior for compatibility for now, though we can of course discuss whether it should be deprecated or removed.

**setup.py before**

```python
NAME = 'astropy'

# VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
VERSION = '3.2.dev'

# Indicates if this version is a release version
RELEASE = 'dev' not in VERSION

if not RELEASE:
    VERSION += get_git_devstr(False)

# Populate the dict of setup command overrides
cmdclassd = register_commands(NAME, VERSION, RELEASE)

# Freeze build information in version.py
generate_version_py(NAME, VERSION, RELEASE, get_debug_option(NAME),
                    uses_git=not RELEASE)
```

**setup.py after**

```python
# Populate the dict of setup command overrides
cmdclassd = register_commands()

# Freeze build information in version.py
version = generate_version_py()
```

In terms of deprecation/removal of the old way, one option is to simply add ``*args, **kwargs`` to the function signatures and ignore any input. This might not break anything since most packages already have a ``setup.cfg`` file. But maybe safer to keep things as-is and backward-compatible for now.

Improving the underlying functions is beyond the scope of this PR - I merely want to simplify the API which will make setup.py files simpler. 

Fixes https://github.com/astropy/astropy-helpers/issues/438