### PR TITLE
Include package name in error message for ah_bootstrap.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,7 +70,8 @@ astropy-helpers Changelog
 2.0.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Include package name in error message for Python version in ``ah_bootstrap.py``.
+  [#441]
 
 
 2.0.8 (2018-12-04)

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -79,9 +79,9 @@ CFG_OPTIONS = [
 
 # Start off by parsing the setup.cfg file
 
-if os.path.exists('setup.cfg'):
+SETUP_CFG = ConfigParser()
 
-    SETUP_CFG = ConfigParser()
+if os.path.exists('setup.cfg'):
 
     try:
         SETUP_CFG.read('setup.cfg')
@@ -93,11 +93,6 @@ if os.path.exists('setup.cfg'):
             "Error reading setup.cfg: {0!r}\n{1} will not be "
             "automatically bootstrapped and package installation may fail."
             "\n{2}".format(e, PACKAGE_NAME, _err_help_msg))
-        SETUP_CFG = {}
-
-else:
-
-    SETUP_CFG = {}
 
 __minimum_python_version__ = (3, 5)
 


### PR DESCRIPTION
I decided to also move the parsing on setup.cfg to the top of the file which require reordering a bunch of stuff, hence the diff. With this, the error message looks like:

```
ERROR: Python (3, 6) or later is required by astropy-helpers for astropy
```

@drdavella @Cadair - is that clear enough?