### PR TITLE
Remove mention of get_entry_points which isn't actually implemented

### DIFF
--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -416,9 +416,6 @@ def get_package_info(srcdir='.', exclude=()):
     - ``get_external_libraries()`` returns
       a list of libraries that can optionally be built using external
       dependencies.
-
-    - ``get_entry_points()`` returns a dict formatted as required by
-      the ``entry_points`` argument to ``setup()``.
     """
     ext_modules = []
     packages = []

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -222,10 +222,6 @@ these files can include one or more of the following functions:
     ``get_extensions`` function to determine if the package should use
     the system library or the included one.
 
-* ``get_entry_points()``:
-    This function can returns a dict formatted as required by
-    the ``entry_points`` argument to ``setup()``.
-
 With these files in place, you can either use the simplified method of opting in
 to astropy-helpers described in :ref:`setup_all`, or if you want more control,
 use theyou can then make use of the


### PR DESCRIPTION
Just removing docs about a feature that doesn't exist.