### PR TITLE
Write error messages on stderr

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -123,20 +123,22 @@ if SETUP_CFG.has_option('options', 'python_requires'):
 
     if not req.specifier.contains(python_version):
         if parent_package is None:
-            print("ERROR: Python {} is required by this package".format(req.specifier))
+            message = "ERROR: Python {} is required by this package\n".format(req.specifier)
         else:
-            print("ERROR: Python {} is required by {}".format(req.specifier, parent_package))
+            message = "ERROR: Python {} is required by {}\n".format(req.specifier, parent_package)
+        sys.stderr.write(message)
         sys.exit(1)
 
 if sys.version_info < __minimum_python_version__:
 
     if parent_package is None:
-        print("ERROR: Python {} or later is required by astropy-helpers".format(
-            __minimum_python_version__))
+        message = "ERROR: Python {} or later is required by astropy-helpers\n".format(
+            __minimum_python_version__)
     else:
-        print("ERROR: Python {} or later is required by astropy-helpers for {}".format(
-            __minimum_python_version__, parent_package))
+        message = "ERROR: Python {} or later is required by astropy-helpers for {}\n".format(
+            __minimum_python_version__, parent_package)
 
+    sys.stderr.write(message)
     sys.exit(1)
 
 _str_types = (str, bytes)
@@ -153,7 +155,7 @@ try:
     import setuptools
     assert LooseVersion(setuptools.__version__) >= LooseVersion('30.3')
 except (ImportError, AssertionError):
-    print("ERROR: setuptools 30.3 or later is required by astropy-helpers")
+    sys.stderr.write("ERROR: setuptools 30.3 or later is required by astropy-helpers\n")
     sys.exit(1)
 
 # typing as a dependency for 1.6.1+ Sphinx causes issues when imported after

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -4,7 +4,7 @@ This module contains a number of utilities for use during
 setup/build/packaging that are useful to astropy as a whole.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
 import collections
 import os
@@ -192,7 +192,7 @@ def register_commands(package=None, version=None, release=None, srcdir='.'):
     elif package is not None:  # deprecated
         pass
     else:
-        print('ERROR: Could not read package name from setup.cfg', file=sys.stderr)
+        sys.stderr.write('ERROR: Could not read package name from setup.cfg\n')
         sys.exit(1)
 
     if conf.has_option('metadata', 'version'):
@@ -200,7 +200,7 @@ def register_commands(package=None, version=None, release=None, srcdir='.'):
     elif version is not None:  # deprecated
         pass
     else:
-        print('ERROR: Could not read package version from setup.cfg', file=sys.stderr)
+        sys.stderr.write('ERROR: Could not read package version from setup.cfg\n')
         sys.exit(1)
 
     release = 'dev' not in version

--- a/astropy_helpers/version_helpers.py
+++ b/astropy_helpers/version_helpers.py
@@ -271,7 +271,7 @@ def generate_version_py(packagename=None, version=None, release=None, debug=None
     elif packagename is not None:  # deprecated
         pass
     else:
-        print('ERROR: Could not read package name from setup.cfg', file=sys.stderr)
+        sys.stderr.write('ERROR: Could not read package name from setup.cfg\n')
         sys.exit(1)
 
     if conf.has_option('metadata', 'version'):
@@ -280,7 +280,7 @@ def generate_version_py(packagename=None, version=None, release=None, debug=None
     elif version is not None:  # deprecated
         add_git_devstr = False
     else:
-        print('ERROR: Could not read package version from setup.cfg', file=sys.stderr)
+        sys.stderr.write('ERROR: Could not read package version from setup.cfg\n')
         sys.exit(1)
 
     if release is None:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import setuptools
 from setuptools import setup
 
 if LooseVersion(setuptools.__version__) < '30.3':
-    print("ERROR: setuptools 30.3 or later is required by astropy-helpers")
+    sys.stderr.write("ERROR: setuptools 30.3 or later is required by astropy-helpers\n")
     sys.exit(1)
 
 from astropy_helpers.version_helpers import generate_version_py  # noqa


### PR DESCRIPTION
Some messages were using `file` on `print`, whereas other where just simple
`print`s. Now all are using `sys.stderr.write`.