### PR TITLE
Preserve package data defined in [options.package_data]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ astropy-helpers Changelog
 3.2 (unreleased)
 ----------------
 
+- Make sure that ``[options.package_data]`` in setup.cfg is taken into account
+  when collecting package data. [#453]
+
 - Simplified the code for the custom build_ext command. [#446]
 
 - Avoid importing the astropy package when trying to get the test command

--- a/astropy_helpers/setup_helpers.py
+++ b/astropy_helpers/setup_helpers.py
@@ -418,8 +418,18 @@ def get_package_info(srcdir='.', exclude=()):
     """
     ext_modules = []
     packages = []
-    package_data = {}
     package_dir = {}
+
+    # Read in existing package data, and add to it below
+    setup_cfg = os.path.join(srcdir, 'setup.cfg')
+    if os.path.exists(setup_cfg):
+        conf = read_configuration(setup_cfg)
+        if 'options' in conf and 'package_data' in conf['options']:
+            package_data = conf['options']['package_data']
+        else:
+            package_data = {}
+    else:
+        package_data = {}
 
     if exclude:
         warnings.warn(


### PR DESCRIPTION
Currently, astropy-helpers's ``get_package_info`` function ignores package data defined in ``setup.cfg``. This fixes things so that we start off from what's defined in ``setup.cfg`` then iterate through the ``setup_package.py`` files. Not really worth backporting since including data in ``[options.package_data]`` hasn't been standard practice for us so far (though I hope to change that).