### PR TITLE
Updating bundled sphinx extensions to match sphinx-astropy 1.1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ astropy-helpers Changelog
 
 - Updated bundled version of sphinx-automodapi to v0.10. [#439]
 
+- Updated bundled sphinx extensions version to sphinx-astropy v1.1.1. [#454]
+
 - Include package name in error message for Python version in
   ``ah_bootstrap.py``. [#441]
 

--- a/astropy_helpers/sphinx/ext/changelog_links.py
+++ b/astropy_helpers/sphinx/ext/changelog_links.py
@@ -7,8 +7,12 @@ GitHub issues.
 from __future__ import print_function
 
 import re
-
+from distutils.version import LooseVersion
 from docutils.nodes import Text, reference
+
+from sphinx import __version__
+
+SPHINX_LT_16 = LooseVersion(__version__) < LooseVersion('1.6')
 
 BLOCK_PATTERN = re.compile('\[#.+\]', flags=re.DOTALL)
 ISSUE_PATTERN = re.compile('#[0-9]+')
@@ -22,7 +26,13 @@ def process_changelog_links(app, doctree, docname):
         # if the doc doesn't match any of the changelog regexes, don't process
         return
 
-    app.info('[changelog_links] Adding changelog links to "{0}"'.format(docname))
+    if SPHINX_LT_16:
+        info = app.info
+    else:
+        from sphinx.util import logging
+        info = logging.getLogger(__name__).info
+
+    info('[changelog_links] Adding changelog links to "{0}"'.format(docname))
 
     for item in doctree.traverse():
 


### PR DESCRIPTION
This should get rid of the sphinx deprecation warning. Once merged 2.0.9 is ready for release.