### PR TITLE
Make sure we directly install mpl for py3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,10 +45,10 @@ distribute-*.tar.gz
 .coverage
 cover
 htmlcov
+.pytest_cache
 
 # Mac OSX
 .DS_Store
 
 # PyCharm
 .idea
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ sudo: false
 
 env:
   matrix:
-    # CONDA_DEPENDENCIES are necessary for python3.5 build as sphinx-gallery doesn't
-    # recognize mpl python requirement (see jobs below, too)
-    - PYTHON_VERSION=3.5 CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES 'matplotlib<3.1'`"
+    - PYTHON_VERSION=3.5
     - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7 SETUPTOOLS_VERSION=dev DEBUG=True
       CONDA_DEPENDENCIES='sphinx cython numpy pytest-cov'
@@ -36,7 +34,6 @@ matrix:
       env: PYTHON_VERSION=3.6 SPHINX_VERSION='1.5' SETUPTOOLS_VERSION=30
     - os: linux
       env: PYTHON_VERSION=3.5 SPHINX_VERSION='1.4' SETUPTOOLS_VERSION=30
-           CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES 'matplotlib<3.1'`"
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx codecov'
            CONDA_DEPENDENCIES="setuptools cython numpy pytest-cov" EVENT_TYPE='push pull_request cron'
@@ -49,7 +46,7 @@ matrix:
     - os: osx
       env:
         - PYTHON_VERSION=3.5
-        - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov clang llvm-openmp 'matplotlib<3.1'"
+        - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov clang llvm-openmp matplotlib"
         - OPENMP_EXPECTED=True
         - CCOMPILER=clang
 
@@ -57,7 +54,7 @@ matrix:
     - os: osx
       env:
         - PYTHON_VERSION=3.5
-        - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov gcc 'matplotlib<3.1'"
+        - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov gcc sphinx-astropy"
         - OPENMP_EXPECTED=True
         - CCOMPILER=gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,19 @@ sudo: false
 
 env:
   matrix:
-    - PYTHON_VERSION=3.5
+    # CONDA_DEPENDENCIES are necessary for python3.5 build as sphinx-gallery doesn't
+    # recognize mpl python requirement (see jobs below, too)
+    - PYTHON_VERSION=3.5 CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES 'matplotlib<3.1'`"
     - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7 SETUPTOOLS_VERSION=dev DEBUG=True
       CONDA_DEPENDENCIES='sphinx cython numpy pytest-cov'
       EVENT_TYPE='push pull_request cron'
 
-
   global:
     - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov"
     - PIP_DEPENDENCIES="codecov"
     - EVENT_TYPE='push pull_request'
+    - DEBUG=True
 
 matrix:
   include:
@@ -34,6 +36,7 @@ matrix:
       env: PYTHON_VERSION=3.6 SPHINX_VERSION='1.5' SETUPTOOLS_VERSION=30
     - os: linux
       env: PYTHON_VERSION=3.5 SPHINX_VERSION='1.4' SETUPTOOLS_VERSION=30
+           CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES 'matplotlib<3.1'`"
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx codecov'
            CONDA_DEPENDENCIES="setuptools cython numpy pytest-cov" EVENT_TYPE='push pull_request cron'
@@ -46,7 +49,7 @@ matrix:
     - os: osx
       env:
         - PYTHON_VERSION=3.5
-        - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov clang llvm-openmp"
+        - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov clang llvm-openmp 'matplotlib<3.1'"
         - OPENMP_EXPECTED=True
         - CCOMPILER=clang
 
@@ -54,7 +57,7 @@ matrix:
     - os: osx
       env:
         - PYTHON_VERSION=3.5
-        - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov gcc"
+        - CONDA_DEPENDENCIES="setuptools sphinx cython numpy pytest-cov gcc 'matplotlib<3.1'"
         - OPENMP_EXPECTED=True
         - CCOMPILER=gcc
 

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -57,6 +57,14 @@ def ensure_sphinx_astropy_installed():
 
         from setuptools import Distribution
         dist = Distribution()
+
+        # This egg build doesn't respect python_requires, not aware of
+        # pre-releases. We know that mpl 3.1+ requires Python 3.6+, so this
+        # ugly workaround takes care of it until there is a solution for
+        # https://github.com/astropy/astropy-helpers/issues/462
+        if LooseVersion(sys.version) < LooseVersion('3.6'):
+            dist.fetch_build_eggs('matplotlib<3.1')
+
         eggs = dist.fetch_build_eggs('sphinx-astropy')
 
         # Find out the version of sphinx-astropy if possible. For some old


### PR DESCRIPTION
This is to workaround #462, as I couldn't find the way to make setuptools understand `python_require` (nor pre-release, but that's an issue already been reported upstream: https://github.com/pypa/setuptools/issues/855).

There is another instance of `fetch_build_eggs()` in `ah_bootstrap.py`, but I leave that one alone for now as packages listing their dependencies should know what 