### PR TITLE
Workaround numpydoc new sphinx requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     - os: linux
       env: PYTHON_VERSION=3.6 SPHINX_VERSION='1.5' SETUPTOOLS_VERSION=30
     - os: linux
-      env: PYTHON_VERSION=3.5 SPHINX_VERSION='1.4' SETUPTOOLS_VERSION=30
+      env: PYTHON_VERSION=3.5 SPHINX_VERSION='1.5' SETUPTOOLS_VERSION=30
            CONDA_DEPENDENCIES=`echo $CONDA_DEPENDENCIES sphinx-astropy 'numpydoc<0.9'`"
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx codecov'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
       env: PYTHON_VERSION=3.6 SPHINX_VERSION='1.5' SETUPTOOLS_VERSION=30
     - os: linux
       env: PYTHON_VERSION=3.5 SPHINX_VERSION='1.4' SETUPTOOLS_VERSION=30
+           CONDA_DEPENDENCIES=`echo $CONDA_DEPENDENCIES sphinx-astropy 'numpydoc<0.9'`"
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx codecov'
            CONDA_DEPENDENCIES="setuptools cython numpy pytest-cov" EVENT_TYPE='push pull_request cron'

--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -17,6 +17,7 @@ from sphinx.setup_command import BuildDoc as SphinxBuildDoc
 
 from ..utils import AstropyDeprecationWarning
 
+SPHINX_LT_16 = LooseVersion(sphinx_version) < LooseVersion('1.6')
 SPHINX_LT_17 = LooseVersion(sphinx_version) < LooseVersion('1.7')
 
 SUBPROCESS_TEMPLATE = """
@@ -57,6 +58,11 @@ def ensure_sphinx_astropy_installed():
 
         from setuptools import Distribution
         dist = Distribution()
+
+        # Numpydoc 0.9.0 requires sphinx 1.6+, we can limit the version here
+        # until we also makes our minimum required version Sphinx 1.6
+        if SPHINX_LT_16:
+            dist.fetch_build_eggs('numpydoc<0.9')
 
         # This egg build doesn't respect python_requires, not aware of
         # pre-releases. We know that mpl 3.1+ requires Python 3.6+, so this


### PR DESCRIPTION
As the title says this is purely a workaround, and I support to consider setting sphinx>=1.6 as a requirement for astropy-helpers 3.2, too (via a new sphinx-astropy release).
