### PR TITLE
Ignore .coverage.subprocess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ distribute-*.tar.gz
 .pydevproject
 .settings
 .coverage
+.coverage.subprocess
 cover
 htmlcov
 .pytest_cache


### PR DESCRIPTION
I keep seeing this as untracked file after I run the tests locally.