### PR TITLE
Fix compiler.c not included in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include README.rst
 include CHANGES.rst
 include LICENSE.rst
 recursive-include licenses *
-include astropy_helpers\commands\src\compiler.c
+include astropy_helpers/commands/src/compiler.c
 
 include ah_bootstrap.py
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst
 include CHANGES.rst
 include LICENSE.rst
 recursive-include licenses *
+include astropy_helpers\commands\src\compiler.c
 
 include ah_bootstrap.py
 


### PR DESCRIPTION
Fix building astropy-3.2 from source
```
running build_ext
error: [Errno 2] No such file or directory: '.eggs\\astropy_helpers-3.2-py3.8.egg\\astropy_helpers\\commands\\src\\compiler.c'
```