### PR TITLE
Fix inclusion of compiler.c in tar file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,8 @@ before_script:
     - git config --global user.email "author@example.com"
 
 script:
+
+    # First run tests in the repository
     - pytest --cov astropy_helpers astropy_helpers
 
     # In conftest.py we produce a .coverage.subprocess that contains coverage
@@ -117,6 +119,17 @@ script:
     - mv .coverage .coverage.main
     - coverage combine .coverage.main .coverage.subprocess
     - coverage report
+
+    # Now we need to make sure that things work correctly in the tar file.
+    # However by default we remove the tests from the tar file, so we need to
+    # copy those in.
+    - python setup.py sdist
+    - cd dist
+    - tar xvzf *.tar.gz
+    - rm *.tar.gz
+    - cd astropy-helpers*
+    - cp -RP ../../astropy_helpers/tests astropy_helpers/tests
+    - pytest astropy_helpers
 
 after_success:
     - codecov

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ astropy-helpers Changelog
 3.2.1 (unreleased)
 ------------------
 
-- No changes yet.
+- Make sure that all data files get included in tar file releases. [#485]
 
 
 3.2 (2019-05-29)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
 
 [options]
 zip_safe = False
-include_package_data = True
 python_requires = >=3.5
 packages = find:
 


### PR DESCRIPTION
The ``include_package_data`` option is confusing and results in data files defined in ``setup.cfg`` being ignored, and instead it uses the MANIFEST. So I've removed the ``include_package_data`` option since I think defining the data in ``setup.cfg`` is preferable. With this change, ``compiler.c`` gets included.

This is an alternative to https://github.com/astropy/astropy-helpers/pull/484