### PR TITLE
Correctly handle main package directory inside namespace package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ astropy-helpers Changelog
 3.2.2 (unreleased)
 ------------------
 
-- No changes yet.
+- Correctly handle main package directory inside namespace package. [#486]
 
 
 3.2.1 (2019-06-13)

--- a/astropy_helpers/distutils_helpers.py
+++ b/astropy_helpers/distutils_helpers.py
@@ -57,7 +57,7 @@ def get_main_package_directory(distribution):
     """
     Given a Distribution object, return the main package directory.
     """
-    return min(distribution.packages, key=len)
+    return min(distribution.packages, key=len).replace('.', os.sep)
 
 def get_distutils_option(option, commands):
     """ Returns the value of the given distutils option.


### PR DESCRIPTION
If the main package resides inside a namespace package (e.g. `ligo.skymap` inside `ligo`), then to convert the main package name to a directory, it is necessary to convert all instances of `.` to the path component separator (e.g. `/`).