### PR TITLE
Fix error that occurred when using bare pytest in packages that use astropy-helpers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,7 +124,8 @@ astropy-helpers Changelog
 2.0.11 (unreleased)
 -------------------
 
-- No changes yet.
+- Fixed an issue that caused pytest to crash if it tried to collect
+  tests. [#488]
 
 
 2.0.10 (2019-05-29)

--- a/astropy_helpers/commands/_dummy.py
+++ b/astropy_helpers/commands/_dummy.py
@@ -61,7 +61,7 @@ class _DummyCommandMeta(type):
                 "attribute.")
 
     def __getattribute__(cls, attr):
-        if attr in ('description', 'error_msg'):
+        if attr in ('description', 'error_msg') or attr.startswith('_'):
             # Allow cls.description to work so that `./setup.py
             # --help-commands` still works
             return super(_DummyCommandMeta, cls).__getattribute__(attr)


### PR DESCRIPTION
Note that I think this should be fixed *anyway* because otherwise it will cause issues for any kind of package that tries to do some automatic introspection on ``_DummyCommand``.

Fixes https://github.com/astropy/astropy-helpers/issues/487

@cdeil - ideally we should probably adjust the package template so that ``setup.cfg`` includes options for pytest so that it ignores ``astropy_helpers`` by default. If you know what flag that should be, could you open a PR to the package-template?