### PR TITLE
Correcty typo in error message

### DIFF
--- a/astropy_helpers/commands/build_sphinx.py
+++ b/astropy_helpers/commands/build_sphinx.py
@@ -50,7 +50,7 @@ def ensure_sphinx_astropy_installed():
     try:
         from sphinx_astropy import __version__ as sphinx_astropy_version  # noqa
     except ImportError:
-        raise ImportError("sphinx-astropy needs to be installed to build"
+        raise ImportError("sphinx-astropy needs to be installed to build "
                           "the documentation.")
 
     return sphinx_astropy_version, sys_path_inserts


### PR DESCRIPTION
Without this fix, there is a space missing between "build" and "the"
[skip CI]