### PR TITLE
Revert "Hack to pass -coverage to linker"

### DIFF
--- a/astropy_helpers/openmp_helpers.py
+++ b/astropy_helpers/openmp_helpers.py
@@ -174,11 +174,6 @@ def check_openmp_support(openmp_flags=None):
     compile_flags = openmp_flags.get('compiler_flags')
     link_flags = openmp_flags.get('linker_flags')
 
-    # Pass -coverage flag to linker.
-    # https://github.com/astropy/astropy-helpers/pull/374
-    if '-coverage' in compile_flags and '-coverage' not in link_flags:
-        link_flags.append('-coverage')
-
     tmp_dir = tempfile.mkdtemp()
     start_dir = os.path.abspath('.')
 


### PR DESCRIPTION
This reverts commit b4ffde3dc7bc30b93050e66c7288e79e3058433e.

It did not fix #432.