### PR TITLE
Adding python3.8 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - PYTHON_VERSION=3.7 SETUPTOOLS_VERSION=dev DEBUG=True
       CONDA_DEPENDENCIES="cython numpy pytest-cov sphinx-astropy'
       EVENT_TYPE='push pull_request cron'
+    - PYTHON_VERSION=3.8
 
   global:
     - CONDA_DEPENDENCIES="setuptools sphinx-astropy cython numpy pytest-cov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
     - PYTHON_VERSION=3.7 SETUPTOOLS_VERSION=dev DEBUG=True
       CONDA_DEPENDENCIES="cython numpy pytest-cov sphinx-astropy'
       EVENT_TYPE='push pull_request cron'
-    - PYTHON_VERSION=3.8
 
   global:
     - CONDA_DEPENDENCIES="setuptools sphinx-astropy cython numpy pytest-cov"
@@ -31,6 +30,8 @@ matrix:
     # installation but we want to make sure that test runs for coverage.
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='codecov'
+    - os: linux
+      env: PYTHON_VERSION=3.8
     - os: linux
       env: PYTHON_VERSION=3.6 SPHINX_VERSION='1.7' SETUPTOOLS_VERSION=30
     - os: linux


### PR DESCRIPTION
We need to be sure we're 3.8 compatible with the 4.0 release. RC can be done once this one is merged.