### PR TITLE
Fix compatibility with setuptools 42

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ astropy-helpers Changelog
 
 - Added a --parallel option for build_docs. [#498]
 
+- Fix compatibility with setuptools 42.x. [#504]
 
 3.2.2 (unreleased)
 ------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.rst
 include CHANGES.rst
 include LICENSE.rst
+include pyproject.toml
 recursive-include licenses *
 
 include ah_bootstrap.py

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -163,6 +163,8 @@ except (ImportError, AssertionError):
     sys.stderr.write("ERROR: setuptools 30.3 or later is required by astropy-helpers\n")
     sys.exit(1)
 
+SETUPTOOLS_LT_42 = LooseVersion(setuptools.__version__) < LooseVersion('42')
+
 # typing as a dependency for 1.6.1+ Sphinx causes issues when imported after
 # initializing submodule with ah_boostrap.py
 # See discussion and references in
@@ -533,7 +535,9 @@ class _Bootstrapper(object):
                         opts['find_links'] = ('setup script', find_links)
                     if index_url is not None:
                         opts['index_url'] = ('setup script', index_url)
-                    if allow_hosts is not None:
+                    # For setuptools>=42, the allow_hosts option can't
+                    # be used because pip doesn't support it.
+                    if allow_hosts is not None and SETUPTOOLS_LT_42:
                         opts['allow_hosts'] = ('setup script', allow_hosts)
                 return opts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
I think this fixes https://github.com/astropy/astropy-helpers/issues/501 - basically with setuptools 42 it uses pip to install some eggs during the install process instead of easy_install and the allow-hosts option no longer works. I think the fix here is likely good enough - basically we just ignore allow-hosts for setuptools>=42 in the bootstrap file. The other fix is to add a pyproject.toml file which I think is what would fix #501 - it will ensure wheel is installed before setup.py is called.