### PR TITLE
TST: Fix failing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,13 @@ env:
   matrix:
     - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7 SETUPTOOLS_VERSION=dev DEBUG=True
-      CONDA_DEPENDENCIES="cython numpy pytest-cov sphinx-astropy'
+      CONDA_DEPENDENCIES="cython numpy pytest-cov sphinx-astropy>=1.2 matplotlib>=3.1"
+      CONDA_CHANNELS="astropy"
       EVENT_TYPE='push pull_request cron'
 
   global:
-    - CONDA_DEPENDENCIES="setuptools sphinx-astropy cython numpy pytest-cov"
+    - CONDA_DEPENDENCIES="setuptools sphinx-astropy>=1.2 cython numpy pytest-cov"
+    - CONDA_CHANNELS="astropy"
     - PIP_DEPENDENCIES="codecov"
     - EVENT_TYPE='push pull_request'
     - DEBUG=True
@@ -36,14 +38,13 @@ matrix:
       env: PYTHON_VERSION=3.6 SPHINX_VERSION='1.7' SETUPTOOLS_VERSION=30
     - os: linux
       env: PYTHON_VERSION=3.6 PIP_DEPENDENCIES='git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx codecov'
-           CONDA_DEPENDENCIES="setuptools cython numpy pytest-cov sphinx-astropy"
-           EVENT_TYPE='push pull_request cron' CONDA_CHANNELS="astropy"
+           CONDA_DEPENDENCIES="setuptools cython numpy pytest-cov sphinx-astropy>=1.2"
+           EVENT_TYPE='push pull_request cron'
 
     # Test without installing numpy beforehand to make sure everything works
     # without assuming numpy is already installed
     - os: linux
-      env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='sphinx-astropy cython pytest-cov'
-           CONDA_CHANNELS="astropy"
+      env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='sphinx-astropy>=1.2 cython pytest-cov'
 
     # Windows builds - for now we need to install sphinx-astropy with pip since
     # there is not a recent enough version of graphviz according to conda on Windows
@@ -60,8 +61,7 @@ matrix:
     - os: osx
       env:
         - PYTHON_VERSION=3.7
-        - CONDA_DEPENDENCIES="setuptools sphinx-astropy cython numpy pytest-cov clang llvm-openmp matplotlib"
-        - CONDA_CHANNELS="astropy"
+        - CONDA_DEPENDENCIES="setuptools sphinx-astropy>=1.2 cython numpy pytest-cov clang llvm-openmp matplotlib"
         - OPENMP_EXPECTED=True
         - CCOMPILER=clang
 
@@ -69,8 +69,7 @@ matrix:
     - os: osx
       env:
         - PYTHON_VERSION=3.6
-        - CONDA_DEPENDENCIES="setuptools sphinx-astropy cython numpy pytest-cov gcc"
-        - CONDA_CHANNELS="astropy"
+        - CONDA_DEPENDENCIES="setuptools sphinx-astropy>=1.2 cython numpy pytest-cov gcc"
         - OPENMP_EXPECTED=True
         - CONDA_CHANNELS="astropy conda-forge"
         - CCOMPILER=gcc
@@ -81,7 +80,7 @@ matrix:
   #
   # allow_failures:
   #   - env: PYTHON_VERSION=3.6 SETUPTOOLS_VERSION=dev DEBUG=True
-  #          CONDA_DEPENDENCIES='sphinx-astropy cython numpy pytest-cov'
+  #          CONDA_DEPENDENCIES='sphinx-astropy>=1.2 cython numpy pytest-cov'
   #          EVENT_TYPE='push pull_request cron'
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ sudo: false
 
 env:
   matrix:
-    - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7 SETUPTOOLS_VERSION=dev DEBUG=True
-      CONDA_DEPENDENCIES="cython numpy pytest-cov sphinx-astropy>=1.2 matplotlib>=3.1"
+      CONDA_DEPENDENCIES="cython numpy pytest-cov sphinx-astropy>=1.2"
       CONDA_CHANNELS="astropy"
       EVENT_TYPE='push pull_request cron'
 
@@ -27,6 +26,9 @@ env:
 
 matrix:
   include:
+
+    - os: linux
+      env: PYTHON_VERSION=3.6
 
     # Do one build with sphinx-astropy as one of the tests bypasses the auto-
     # installation but we want to make sure that test runs for coverage.

--- a/astropy_helpers/tests/test_git_helpers.py
+++ b/astropy_helpers/tests/test_git_helpers.py
@@ -1,5 +1,5 @@
 import glob
-import imp
+import importlib as imp
 import os
 import pkgutil
 import re

--- a/astropy_helpers/utils.py
+++ b/astropy_helpers/utils.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import contextlib
-import imp
+import importlib as imp
 import os
 import sys
 import glob

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ norecursedirs =
     .tox
     astropy_helpers/tests/package_template
 python_functions = test_
+filterwarnings =
+    ignore:.*argument to generate_version_py
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Unrelated failures were seen at #511 , blocking it from proceeding.

The real problem: `sphinx-astropy` not found on `conda`.

Bonus: Remove or ignore warnings.