### PR TITLE
Fix CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
       EVENT_TYPE='push pull_request cron'
 
   global:
+    - MAMBA=True
     - CONDA_DEPENDENCIES="setuptools sphinx-astropy cython numpy pytest-cov"
     - PIP_DEPENDENCIES="codecov"
     - EVENT_TYPE='push pull_request'

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,16 +66,6 @@ matrix:
         - OPENMP_EXPECTED=True
         - CCOMPILER=clang
 
-    # Test gcc on OSX
-    - os: osx
-      env:
-        - PYTHON_VERSION=3.6
-        - CONDA_DEPENDENCIES="setuptools sphinx-astropy cython numpy pytest-cov gcc"
-        - CONDA_CHANNELS="astropy"
-        - OPENMP_EXPECTED=True
-        - CONDA_CHANNELS="astropy conda-forge"
-        - CCOMPILER=gcc
-
   # Uncomment the following if there are issues in setuptools that we
   # can't work around quickly - otherwise leave uncommented so that
   # we notice when things go wrong.


### PR DESCRIPTION
Use mamba to avoid conda issues that are causing CI failures (https://github.com/astropy/astropy-helpers/pull/512) - mamba is generally better with any kind of conflicts etc.